### PR TITLE
SK-536 Set Token Not Behaving Properly in Android SDK

### DIFF
--- a/Skyflow/src/main/kotlin/Skyflow/Label.kt
+++ b/Skyflow/src/main/kotlin/Skyflow/Label.kt
@@ -14,9 +14,9 @@ import androidx.core.content.res.ResourcesCompat
 @Suppress("DEPRECATION")
 class Label @JvmOverloads constructor(
     context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0,
-) : LinearLayout(context, attrs, defStyleAttr),BaseElement {
+) : LinearLayout(context, attrs, defStyleAttr), BaseElement {
 
-    internal  var actualValue: String? =null
+    internal var actualValue: String? = null
     internal var label = TextView(context)
     internal var placeholder = TextView(context)
     internal var error = TextView(context)
@@ -28,17 +28,16 @@ class Label @JvmOverloads constructor(
     internal var isError = false
     internal var uuid = ""
 
-    fun getID(): String{
+    fun getID(): String {
         return uuid
     }
+
     @SuppressLint("NewApi", "WrongConstant")
-    internal fun setupField(revealInput: RevealElementInput, options: RevealElementOptions)
-    {
+    internal fun setupField(revealInput: RevealElementInput, options: RevealElementOptions) {
         this.revealInput = revealInput
         this.options = options
         padding = revealInput.inputStyles.base.padding
-        if(this.revealInput.token.equals(null))
-        {
+        if (this.revealInput.token.equals(null)) {
             isTokenNull = true
             this.revealInput.token = ""
         }
@@ -51,22 +50,31 @@ class Label @JvmOverloads constructor(
         error.text = " "
         error.textSize = 16F
         val errorPadding = revealInput.errorTextStyles.base.padding
-        error.setPadding(errorPadding.left,errorPadding.top,errorPadding.right,errorPadding.bottom)
+        error.setPadding(
+            errorPadding.left,
+            errorPadding.top,
+            errorPadding.right,
+            errorPadding.bottom
+        )
         error.setTextColor(revealInput.errorTextStyles.base.textColor)
-        if(revealInput.errorTextStyles.base.font != Typeface.NORMAL)
-          error.typeface = ResourcesCompat.getFont(context,revealInput.errorTextStyles.base.font)
+        if (revealInput.errorTextStyles.base.font != Typeface.NORMAL)
+            error.typeface = ResourcesCompat.getFont(context, revealInput.errorTextStyles.base.font)
         error.gravity = revealInput.errorTextStyles.base.textAlignment
     }
 
     private fun buildPlaceholder() {
         setText()
-        if(revealInput.inputStyles.base.font != Typeface.NORMAL)
-             placeholder.typeface = ResourcesCompat.getFont(context,revealInput.inputStyles.base.font)
+        if (revealInput.inputStyles.base.font != Typeface.NORMAL)
+            placeholder.typeface =
+                ResourcesCompat.getFont(context, revealInput.inputStyles.base.font)
         placeholder.textSize = 20f
         placeholder.gravity = revealInput.inputStyles.base.textAlignment
-        placeholder.setPadding(padding.left,padding.top,padding.right,padding.bottom)
+        placeholder.setPadding(padding.left, padding.top, padding.right, padding.bottom)
         placeholder.setTextColor(revealInput.inputStyles.base.textColor)
-        border.setStroke(revealInput.inputStyles.base.borderWidth,revealInput.inputStyles.base.borderColor)
+        border.setStroke(
+            revealInput.inputStyles.base.borderWidth,
+            revealInput.inputStyles.base.borderColor
+        )
         border.cornerRadius = revealInput.inputStyles.base.cornerRadius
         placeholder.setBackgroundDrawable(border)
     }
@@ -77,11 +85,16 @@ class Label @JvmOverloads constructor(
         val labelPadding = revealInput.labelStyles.base.padding
         label.text = revealInput.label
         label.textSize = 16F
-        label.setPadding(labelPadding.left,labelPadding.top,labelPadding.right,labelPadding.bottom)
+        label.setPadding(
+            labelPadding.left,
+            labelPadding.top,
+            labelPadding.right,
+            labelPadding.bottom
+        )
         label.setTextColor(revealInput.labelStyles.base.textColor)
         label.gravity = revealInput.labelStyles.base.textAlignment
-        if(revealInput.labelStyles.base.font != Typeface.NORMAL)
-            label.typeface = ResourcesCompat.getFont(context,revealInput.labelStyles.base.font)
+        if (revealInput.labelStyles.base.font != Typeface.NORMAL)
+            label.typeface = ResourcesCompat.getFont(context, revealInput.labelStyles.base.font)
     }
 
     override fun onAttachedToWindow() {
@@ -92,16 +105,16 @@ class Label @JvmOverloads constructor(
         addView(error)
     }
 
-    fun setErrorText(error:String)
-    {
+    fun setErrorText(error: String) {
         this.error.text = error
     }
 
     internal fun getValue(): String {
-        if(actualValue != null)
+        if (actualValue != null)
             return actualValue!!
         return ""
     }
+
     override fun setError(error: String) {
         isError = true
         setErrorText(error)
@@ -113,7 +126,7 @@ class Label @JvmOverloads constructor(
         hideError()
     }
 
-    internal fun showError(){
+    internal fun showError() {
         setErrorStyles()
         setInvalidStyles()
         this.error.visibility = VISIBLE
@@ -126,84 +139,87 @@ class Label @JvmOverloads constructor(
         buildLabel()
     }
 
-    private fun setInvalidStyles(){
-        if(this.revealInput.inputStyles.invalid.font != Typeface.NORMAL)
-            this.placeholder.typeface = ResourcesCompat.getFont(this.context,this.revealInput.inputStyles.invalid.font)
+    private fun setInvalidStyles() {
+        if (this.revealInput.inputStyles.invalid.font != Typeface.NORMAL)
+            this.placeholder.typeface =
+                ResourcesCompat.getFont(this.context, this.revealInput.inputStyles.invalid.font)
         this.placeholder.gravity =
             this.revealInput.inputStyles.invalid.textAlignment
         val padding = this.revealInput.inputStyles.invalid.padding
-        this.placeholder.setPadding(padding.left,
+        this.placeholder.setPadding(
+            padding.left,
             padding.top,
             padding.right,
-            padding.bottom)
+            padding.bottom
+        )
         this.placeholder.setTextColor(this.revealInput.inputStyles.invalid.textColor)
-        this.border.setStroke(this.revealInput.inputStyles.invalid.borderWidth,
-            this.revealInput.inputStyles.invalid.borderColor)
+        this.border.setStroke(
+            this.revealInput.inputStyles.invalid.borderWidth,
+            this.revealInput.inputStyles.invalid.borderColor
+        )
         this.border.cornerRadius =
             this.revealInput.inputStyles.invalid.cornerRadius
         this.placeholder.setBackgroundDrawable(this.border)
     }
 
-    private fun setErrorStyles(){
+    private fun setErrorStyles() {
         error.textSize = 16F
         val errorPadding = revealInput.errorTextStyles.base.padding
-        error.setPadding(errorPadding.left,errorPadding.top,errorPadding.right,errorPadding.bottom)
+        error.setPadding(
+            errorPadding.left,
+            errorPadding.top,
+            errorPadding.right,
+            errorPadding.bottom
+        )
         error.setTextColor(revealInput.errorTextStyles.base.textColor)
-        if(revealInput.errorTextStyles.base.font != Typeface.NORMAL)
-            error.typeface = ResourcesCompat.getFont(context,revealInput.errorTextStyles.base.font)
+        if (revealInput.errorTextStyles.base.font != Typeface.NORMAL)
+            error.typeface = ResourcesCompat.getFont(context, revealInput.errorTextStyles.base.font)
         error.gravity = revealInput.errorTextStyles.base.textAlignment
     }
 
-    internal fun getErrorText() :String
-    {
+    internal fun getErrorText(): String {
         return this.error.text.toString()
     }
 
-    fun setToken(token : String)
-    {
+    fun setToken(token: String) {
         this.revealInput.token = token
+        this.isTokenNull = false;
         setText()
     }
-    fun setAltText(altText:String)
-    {
+
+    fun setAltText(altText: String) {
         this.revealInput.altText = altText
         setText()
-
     }
 
-    fun clearAltText()
-    {
+    fun clearAltText() {
         this.revealInput.altText = ""
-        if(this.actualValue != null)
+        if (this.actualValue != null)
             placeholder.text = actualValue
         else
             placeholder.text = getToken()
     }
 
-    private fun setText()
-    {
-        if(revealInput.altText.isEmpty() || revealInput.altText == "")
-        {
+    private fun setText() {
+        if (revealInput.altText.isEmpty() || revealInput.altText == "") {
             placeholder.text = revealInput.token
-        }
-        else
+        } else
             placeholder.text = revealInput.altText
     }
 
-    internal fun setText(t:String)
-    {
+    internal fun setText(t: String) {
         this.placeholder.text = t
         actualValue = t
     }
 
-    fun getToken() : String {
-         if(revealInput.token != null)
-             return revealInput.token!!
+    fun getToken(): String {
+        if (revealInput.token != null)
+            return revealInput.token!!
         return ""
     }
 
     internal fun getValueForConnections(): String {
-        if(actualValue != null) return actualValue!!
+        if (actualValue != null) return actualValue!!
         return getToken()
     }
 

--- a/Skyflow/src/main/kotlin/Skyflow/RevealContainer.kt
+++ b/Skyflow/src/main/kotlin/Skyflow/RevealContainer.kt
@@ -13,62 +13,85 @@ import org.json.JSONObject
 import java.lang.Exception
 import java.util.*
 
-class RevealContainer: ContainerProtocol
-{
+class RevealContainer : ContainerProtocol {
     private val tag = RevealContainer::class.qualifiedName
 }
 
 private val tag = RevealContainer::class.qualifiedName
 
-fun Container<RevealContainer>.create(context: Context, input : RevealElementInput, options : RevealElementOptions = RevealElementOptions()) : Label
-{
-    Logger.info(tag, Messages.CREATED_REVEAL_ELEMENT.getMessage(input.label), configuration.options.logLevel)
+fun Container<RevealContainer>.create(
+    context: Context,
+    input: RevealElementInput,
+    options: RevealElementOptions = RevealElementOptions()
+): Label {
+    Logger.info(
+        tag,
+        Messages.CREATED_REVEAL_ELEMENT.getMessage(input.label),
+        configuration.options.logLevel
+    )
+
     val revealElement = Label(context)
-    revealElement.setupField(input,options)
+    revealElement.setupField(input, options)
     revealElements.add(revealElement)
+
     val uuid = UUID.randomUUID().toString()
-    client.elementMap.put(uuid,revealElement)
+    client.elementMap.put(uuid, revealElement)
     revealElement.uuid = uuid
+
     return revealElement
 }
 
-fun Container<RevealContainer>.reveal(callback: Callback, options: RevealOptions? = RevealOptions())
-{
+fun Container<RevealContainer>.reveal(
+    callback: Callback,
+    options: RevealOptions? = RevealOptions()
+) {
     try {
         Utils.checkVaultDetails(client.configuration)
         validateElements()
-        Logger.info(tag, Messages.VALIDATE_REVEAL_RECORDS.getMessage(), configuration.options.logLevel)
-        get(callback,options)
-    }
-    catch (e: Exception)
-    {
+        Logger.info(
+            tag,
+            Messages.VALIDATE_REVEAL_RECORDS.getMessage(),
+            configuration.options.logLevel
+        )
+        get(callback, options)
+    } catch (e: Exception) {
         callback.onFailure(Utils.constructError(e))
     }
 }
 
-internal fun Container<RevealContainer>.validateElements()
-{
+internal fun Container<RevealContainer>.validateElements() {
     for (element in this.revealElements) {
         val token = element.revealInput.token
-        if(!checkIfElementsMounted(element))
-        {
-            throw SkyflowError(SkyflowErrorCode.ELEMENT_NOT_MOUNTED, tag, configuration.options.logLevel, arrayOf(element.revealInput.label))
-        }
-        if (element.isTokenNull) {
-            throw SkyflowError(SkyflowErrorCode.MISSING_TOKEN, tag, configuration.options.logLevel)
-        }  else if (token!!.isEmpty()) {
-            throw SkyflowError(SkyflowErrorCode.EMPTY_TOKEN_ID, tag, configuration.options.logLevel)
-        }
-        else if(element.isError)
-        {
-            throw SkyflowError(SkyflowErrorCode.INVALID_INPUT, tag, configuration.options.logLevel, arrayOf("${element.error.text}"))
+        if (!checkIfElementsMounted(element)) {
+            throw SkyflowError(
+                SkyflowErrorCode.ELEMENT_NOT_MOUNTED,
+                tag,
+                configuration.options.logLevel,
+                arrayOf(element.revealInput.label)
+            )
         }
 
+        if (element.isTokenNull) {
+            throw SkyflowError(SkyflowErrorCode.MISSING_TOKEN, tag, configuration.options.logLevel)
+        } else if (token!!.isEmpty()) {
+            throw SkyflowError(SkyflowErrorCode.EMPTY_TOKEN_ID, tag, configuration.options.logLevel)
+        } else if (element.isError) {
+            throw SkyflowError(
+                SkyflowErrorCode.INVALID_INPUT,
+                tag,
+                configuration.options.logLevel,
+                arrayOf("${element.error.text}")
+            )
+        }
     }
 }
-internal fun Container<RevealContainer>.get(callback: Callback, options: RevealOptions?)
-{
-    val revealValueCallback = RevealValueCallback(callback, this.revealElements,configuration.options.logLevel)
+
+internal fun Container<RevealContainer>.get(callback: Callback, options: RevealOptions?) {
+    val revealValueCallback = RevealValueCallback(
+        callback,
+        this.revealElements,
+        configuration.options.logLevel
+    )
     val records = JSONObject(RevealRequestBody.createRequestBody(this.revealElements))
     this.client.apiClient.get(records, revealValueCallback)
 }

--- a/Skyflow/src/main/kotlin/Skyflow/RevealElementInput.kt
+++ b/Skyflow/src/main/kotlin/Skyflow/RevealElementInput.kt
@@ -1,14 +1,14 @@
 package Skyflow
 
-
 class RevealElementInput(
     internal var token: String? = null,
-    @Deprecated("redaction parameter is deprecated", level = DeprecationLevel.WARNING) internal var redaction: RedactionType? = null,
+    @Deprecated(
+        "redaction parameter is deprecated",
+        level = DeprecationLevel.WARNING
+    ) internal var redaction: RedactionType? = null,
     internal var inputStyles: Styles = Styles(),
-    internal var labelStyles:Styles = Styles(),
-    internal var errorTextStyles:Styles=Styles(),
-    internal var label: String="",
-    internal var altText:String = ""
-) {
-
-}
+    internal var labelStyles: Styles = Styles(),
+    internal var errorTextStyles: Styles = Styles(),
+    internal var label: String = "",
+    internal var altText: String = ""
+) {}

--- a/Skyflow/src/test/java/com/Skyflow/RevealTest.kt
+++ b/Skyflow/src/test/java/com/Skyflow/RevealTest.kt
@@ -17,13 +17,12 @@ import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.android.controller.ActivityController
 
-
 @RunWith(RobolectricTestRunner::class)
 class RevealTest {
-    lateinit var skyflow: Client
+    private lateinit var skyflow: Client
     private lateinit var activityController: ActivityController<Activity>
     private lateinit var activity: Activity
-    lateinit var layoutParams: ViewGroup.LayoutParams
+    private lateinit var layoutParams: ViewGroup.LayoutParams
 
     @Before
     fun setup() {
@@ -36,46 +35,46 @@ class RevealTest {
         skyflow = Client(configuration)
         layoutParams = ViewGroup.LayoutParams(
             ViewGroup.LayoutParams.WRAP_CONTENT,
-            ViewGroup.LayoutParams.WRAP_CONTENT)
+            ViewGroup.LayoutParams.WRAP_CONTENT
+        )
         activityController = Robolectric.buildActivity(Activity::class.java).setup()
         activity = activityController.get()
     }
 
     @Test
-    fun testRevealElementInput()
-    {
+    fun testRevealElementInput() {
 
-        val revealInput = RevealElementInput("2429-2390-5964-3689",RedactionType.DEFAULT,label = "card number")
-        assertEquals(revealInput.token,"2429-2390-5964-3689")
+        val revealInput =
+            RevealElementInput("2429-2390-5964-3689", RedactionType.DEFAULT, label = "card number")
+        assertEquals(revealInput.token, "2429-2390-5964-3689")
         assertEquals(revealInput.redaction, RedactionType.DEFAULT)
-        assertEquals(revealInput.label,"card number")
+        assertEquals(revealInput.label, "card number")
     }
 
     @Test
-    fun testCreateSkyflowRevealContainer()
-    {
+    fun testCreateSkyflowRevealContainer() {
         val container = skyflow.container(ContainerType.REVEAL)
-         val revealInput = RevealElementInput("2429-2390-5964-3689",RedactionType.DEFAULT,label = "card number")
-        val cardNumber = container.create(activity,revealInput, RevealElementOptions())
+        val revealInput =
+            RevealElementInput("2429-2390-5964-3689", RedactionType.DEFAULT, label = "card number")
+        val cardNumber = container.create(activity, revealInput, RevealElementOptions())
 
-        assertEquals(cardNumber.placeholder.text.toString(),"2429-2390-5964-3689")
+        assertEquals(cardNumber.placeholder.text.toString(), "2429-2390-5964-3689")
     }
 
     @Test
-    fun testCheckRevealElementsArray()
-    {
+    fun testCheckRevealElementsArray() {
         val container = skyflow.container(ContainerType.REVEAL)
-        val revealInput = RevealElementInput("2429-2390-5964-3689",RedactionType.DEFAULT,label = "card number")
-        val cardNumber = container.create(activity,revealInput, RevealElementOptions())
+        val revealInput =
+            RevealElementInput("2429-2390-5964-3689", RedactionType.DEFAULT, label = "card number")
+        val cardNumber = container.create(activity, revealInput, RevealElementOptions())
 
-        assertEquals(container.revealElements.count(),1)
-        assertEquals(container.revealElements[0].revealInput.token,cardNumber.revealInput.token)
+        assertEquals(container.revealElements.count(), 1)
+        assertEquals(container.revealElements[0].revealInput.token, cardNumber.revealInput.token)
         assertNotNull(container.revealElements[0].revealInput.token)
     }
 
     @Test
-    fun testWitInvalidVaultURLWithLabel()
-    {
+    fun testWitInvalidVaultURLWithLabel() {
         val skyflowConfiguration = Configuration(
             "vault_id",
             "http://sb1.area51.vault.skyflapis.tech",
@@ -84,29 +83,34 @@ class RevealTest {
         val skyflow = Client(skyflowConfiguration)
         val revealContainer = skyflow.container(ContainerType.REVEAL)
         val revealInput = RevealElementInput(
-            "51b1406a-0a30-49bf-b303-0eef66bd502d",RedactionType.PLAIN_TEXT,
-            label =  "expire_date"
+            "51b1406a-0a30-49bf-b303-0eef66bd502d", RedactionType.PLAIN_TEXT,
+            label = "expire_date"
 
         )
-        val revealElement = revealContainer.create(activity, revealInput, Skyflow.RevealElementOptions())
-        activity.addContentView(revealElement,layoutParams)
-        revealContainer.reveal(object : Callback
-        {
+        val revealElement =
+            revealContainer.create(activity, revealInput, Skyflow.RevealElementOptions())
+        activity.addContentView(revealElement, layoutParams)
+        revealContainer.reveal(object : Callback {
             override fun onSuccess(responseBody: Any) {
             }
+
             override fun onFailure(exception: Any) {
-                val skyflowError = SkyflowError(SkyflowErrorCode.INVALID_VAULT_URL,params = arrayOf(skyflowConfiguration.vaultURL))
-                assertEquals(skyflowError.getInternalErrorMessage(),
-                    getErrorMessage(exception as JSONObject))
-                  }
+                val skyflowError = SkyflowError(
+                    SkyflowErrorCode.INVALID_VAULT_URL,
+                    params = arrayOf(skyflowConfiguration.vaultURL)
+                )
+                assertEquals(
+                    skyflowError.getInternalErrorMessage(),
+                    getErrorMessage(exception as JSONObject)
+                )
+            }
 
         })
     }
 
 
     @Test
-    fun testEmptyVaultIDWithLabel()
-    {
+    fun testEmptyVaultIDWithLabel() {
         val skyflowConfiguration = Configuration(
             "",
             "https://vaulturl.com",
@@ -115,24 +119,28 @@ class RevealTest {
         val skyflow = Client(skyflowConfiguration)
         val revealContainer = skyflow.container(ContainerType.REVEAL)
         val revealInput = RevealElementInput(
-            "51b1406a-0a30-49bf-b303-0eef66bd502d",RedactionType.PLAIN_TEXT,
-           label =  "expire_date"
+            "51b1406a-0a30-49bf-b303-0eef66bd502d", RedactionType.PLAIN_TEXT,
+            label = "expire_date"
         )
-        val revealElement = revealContainer.create(activity, revealInput, Skyflow.RevealElementOptions())
-        revealContainer.reveal(object: Callback {
+        val revealElement =
+            revealContainer.create(activity, revealInput, Skyflow.RevealElementOptions())
+        revealContainer.reveal(object : Callback {
             override fun onSuccess(responseBody: Any) {
-               }
+            }
+
             override fun onFailure(exception: Any) {
                 val skyflowError = SkyflowError(SkyflowErrorCode.EMPTY_VAULT_ID)
-                junit.framework.Assert.assertEquals(skyflowError.getInternalErrorMessage(),
-                    getErrorMessage(exception as JSONObject))
+                junit.framework.Assert.assertEquals(
+                    skyflowError.getInternalErrorMessage(),
+                    getErrorMessage(exception as JSONObject)
+                )
 
-            }})
+            }
+        })
     }
 
     @Test
-    fun testEmptyVaultURLWithLabel()
-    {
+    fun testEmptyVaultURLWithLabel() {
         val skyflowConfiguration = Configuration(
             "vault_id",
             "",
@@ -141,23 +149,27 @@ class RevealTest {
         val skyflow = Client(skyflowConfiguration)
         val revealContainer = skyflow.container(ContainerType.REVEAL)
         val revealInput = RevealElementInput(
-            "51b1406a-0a30-49bf-b303-0eef66bd502d",RedactionType.PLAIN_TEXT,
-            label =  "expire_date"
+            "51b1406a-0a30-49bf-b303-0eef66bd502d", RedactionType.PLAIN_TEXT,
+            label = "expire_date"
         )
-        val revealElement = revealContainer.create(activity, revealInput, Skyflow.RevealElementOptions())
-        revealContainer.reveal(object: Callback {
+        val revealElement =
+            revealContainer.create(activity, revealInput, Skyflow.RevealElementOptions())
+        revealContainer.reveal(object : Callback {
             override fun onSuccess(responseBody: Any) {
             }
+
             override fun onFailure(exception: Any) {
                 val skyflowError = SkyflowError(SkyflowErrorCode.EMPTY_VAULT_URL)
-                assertEquals(skyflowError.getInternalErrorMessage(),
-                    getErrorMessage(exception as JSONObject))
-            }})
+                assertEquals(
+                    skyflowError.getInternalErrorMessage(),
+                    getErrorMessage(exception as JSONObject)
+                )
+            }
+        })
     }
 
     @Test
-    fun testElementNotMounted()
-    {
+    fun testElementNotMounted() {
         val skyflowConfiguration = Configuration(
             "vault_id",
             "https://vaulturl.com",
@@ -166,24 +178,31 @@ class RevealTest {
         val skyflow = Client(skyflowConfiguration)
         val revealContainer = skyflow.container(ContainerType.REVEAL)
         val revealInput = RevealElementInput(
-            "some",RedactionType.PLAIN_TEXT,
-            label =  "expire_date"
+            "some", RedactionType.PLAIN_TEXT,
+            label = "expire_date"
         )
-        val revealElement = revealContainer.create(activity, revealInput, Skyflow.RevealElementOptions())
-        revealContainer.reveal(object: Callback {
+        val revealElement =
+            revealContainer.create(activity, revealInput, Skyflow.RevealElementOptions())
+        revealContainer.reveal(object : Callback {
             override fun onSuccess(responseBody: Any) {
             }
+
             override fun onFailure(exception: Any) {
-                val skyflowError = SkyflowError(SkyflowErrorCode.ELEMENT_NOT_MOUNTED,params = arrayOf(revealElement.label.text.toString()))
-                assertEquals(skyflowError.getInternalErrorMessage(),
-                    getErrorMessage(exception as JSONObject))
-            }})
+                val skyflowError = SkyflowError(
+                    SkyflowErrorCode.ELEMENT_NOT_MOUNTED,
+                    params = arrayOf(revealElement.label.text.toString())
+                )
+                assertEquals(
+                    skyflowError.getInternalErrorMessage(),
+                    getErrorMessage(exception as JSONObject)
+                )
+            }
+        })
     }
 
 
     @Test
-    fun testTokenEmpty()
-    {
+    fun testTokenEmpty() {
         val skyflowConfiguration = Configuration(
             "vault_id",
             "https://vaulturl.com",
@@ -192,24 +211,28 @@ class RevealTest {
         val skyflow = Client(skyflowConfiguration)
         val revealContainer = skyflow.container(ContainerType.REVEAL)
         val revealInput = RevealElementInput(
-            "",RedactionType.PLAIN_TEXT,
-            label =  "expire_date"
+            "", RedactionType.PLAIN_TEXT,
+            label = "expire_date"
         )
-        val revealElement = revealContainer.create(activity, revealInput, Skyflow.RevealElementOptions())
-        activity.addContentView(revealElement,layoutParams)
-        revealContainer.reveal(object: Callback {
+        val revealElement =
+            revealContainer.create(activity, revealInput, Skyflow.RevealElementOptions())
+        activity.addContentView(revealElement, layoutParams)
+        revealContainer.reveal(object : Callback {
             override fun onSuccess(responseBody: Any) {
             }
+
             override fun onFailure(exception: Any) {
                 val skyflowError = SkyflowError(SkyflowErrorCode.EMPTY_TOKEN_ID)
-                assertEquals(skyflowError.getInternalErrorMessage(),
-                    getErrorMessage(exception as JSONObject))
-            }})
+                assertEquals(
+                    skyflowError.getInternalErrorMessage(),
+                    getErrorMessage(exception as JSONObject)
+                )
+            }
+        })
     }
 
     @Test
-    fun testMissingToken()
-    {
+    fun testMissingToken() {
         val skyflowConfiguration = Configuration(
             "vault_id",
             "https://vaulturl.com",
@@ -218,61 +241,98 @@ class RevealTest {
         val skyflow = Client(skyflowConfiguration)
         val revealContainer = skyflow.container(ContainerType.REVEAL)
         val revealInput = RevealElementInput(
-            null,RedactionType.PLAIN_TEXT,
-            label =  "expire_date"
+            null, RedactionType.PLAIN_TEXT,
+            label = "expire_date"
         )
-        val revealElement = revealContainer.create(activity, revealInput, Skyflow.RevealElementOptions())
-        activity.addContentView(revealElement,layoutParams)
-        revealContainer.reveal(object: Callback {
+        val revealElement =
+            revealContainer.create(activity, revealInput, Skyflow.RevealElementOptions())
+        activity.addContentView(revealElement, layoutParams)
+        revealContainer.reveal(object : Callback {
             override fun onSuccess(responseBody: Any) {
             }
+
             override fun onFailure(exception: Any) {
-                assertEquals(revealElement.getValue(),"")
+                assertEquals(revealElement.getValue(), "")
                 val skyflowError = SkyflowError(SkyflowErrorCode.MISSING_TOKEN)
-                assertEquals(skyflowError.getInternalErrorMessage(),
-                    getErrorMessage(exception as JSONObject))
-            }})
-    }
-   
-
-    @Test
-    fun testEmptyStyles()
-    {
-        val revealContainer = skyflow.container(ContainerType.REVEAL)
-        val revealInput = RevealElementInput(
-            "51b1406a-0a30-49bf-b303-0eef66bd502d",RedactionType.PLAIN_TEXT,
-            label =  "expire_date",altText = "expire date"
-
-        )
-        val revealElement = revealContainer.create(activity, revealInput, Skyflow.RevealElementOptions())
-        assertEquals(2,revealElement.revealInput.inputStyles.base.borderWidth)
+                assertEquals(
+                    skyflowError.getInternalErrorMessage(),
+                    getErrorMessage(exception as JSONObject)
+                )
+            }
+        })
     }
 
     @Test
-    fun testEmptyStyle()
-    {
+    fun testNoTokenPassed() {
+        val skyflowConfiguration = Configuration(
+            "vault_id",
+            "https://vaulturl.com",
+            AccessTokenProvider()
+        )
+        val skyflow = Client(skyflowConfiguration)
         val revealContainer = skyflow.container(ContainerType.REVEAL)
         val revealInput = RevealElementInput(
-            "51b1406a-0a30-49bf-b303-0eef66bd502d",RedactionType.PLAIN_TEXT,
-            label =  "expire_date",inputStyles = Styles()
+            redaction = RedactionType.PLAIN_TEXT,
+            label = "expire_date"
+        )
+        val revealElement = revealContainer.create(
+            activity,
+            revealInput,
+            RevealElementOptions()
+        )
+        activity.addContentView(revealElement, layoutParams)
+        revealContainer.reveal(object : Callback {
+            override fun onSuccess(responseBody: Any) {}
+
+            override fun onFailure(exception: Any) {
+                assertEquals(revealElement.getValue(), "")
+                val skyflowError = SkyflowError(SkyflowErrorCode.MISSING_TOKEN)
+                assertEquals(
+                    skyflowError.getInternalErrorMessage(),
+                    getErrorMessage(exception as JSONObject)
+                )
+            }
+        })
+    }
+
+    @Test
+    fun testEmptyStyles() {
+        val revealContainer = skyflow.container(ContainerType.REVEAL)
+        val revealInput = RevealElementInput(
+            "51b1406a-0a30-49bf-b303-0eef66bd502d", RedactionType.PLAIN_TEXT,
+            label = "expire_date", altText = "expire date"
 
         )
-        val revealElement = revealContainer.create(activity, revealInput, Skyflow.RevealElementOptions())
-        assertEquals(2,revealElement.revealInput.inputStyles.base.borderWidth)
+        val revealElement =
+            revealContainer.create(activity, revealInput, Skyflow.RevealElementOptions())
+        assertEquals(2, revealElement.revealInput.inputStyles.base.borderWidth)
+    }
+
+    @Test
+    fun testEmptyStyle() {
+        val revealContainer = skyflow.container(ContainerType.REVEAL)
+        val revealInput = RevealElementInput(
+            "51b1406a-0a30-49bf-b303-0eef66bd502d", RedactionType.PLAIN_TEXT,
+            label = "expire_date", inputStyles = Styles()
+
+        )
+        val revealElement =
+            revealContainer.create(activity, revealInput, Skyflow.RevealElementOptions())
+        assertEquals(2, revealElement.revealInput.inputStyles.base.borderWidth)
 
     }
 
     @Test
-    fun testNullStyle()
-    {
+    fun testNullStyle() {
         val revealContainer = skyflow.container(ContainerType.REVEAL)
         val revealInput = RevealElementInput(
-            "51b1406a-0a30-49bf-b303-0eef66bd502d",RedactionType.PLAIN_TEXT,
-            label =  "expire_date",inputStyles = Styles(null)
+            "51b1406a-0a30-49bf-b303-0eef66bd502d", RedactionType.PLAIN_TEXT,
+            label = "expire_date", inputStyles = Styles(null)
 
         )
-        val revealElement = revealContainer.create(activity, revealInput, Skyflow.RevealElementOptions())
-        assertEquals(2,revealElement.revealInput.inputStyles.base.borderWidth)
+        val revealElement =
+            revealContainer.create(activity, revealInput, Skyflow.RevealElementOptions())
+        assertEquals(2, revealElement.revealInput.inputStyles.base.borderWidth)
 
 
     }
@@ -281,15 +341,14 @@ class RevealTest {
         val errors = error.getJSONArray("errors")
         val skyflowError = errors.getJSONObject(0).get("error") as SkyflowError
         val message = skyflowError.getInternalErrorMessage()
-        if(message.indexOf("-") !=-1)
-            return message.substring(message.indexOf("-")+2)
+        if (message.indexOf("-") != -1)
+            return message.substring(message.indexOf("-") + 2)
         else
             return message
     }
 
     @Test
-    fun testValidReveal()
-    {
+    fun testValidReveal() {
         val skyflowConfiguration = Configuration(
             "vault_id",
             "https://vaulturl.com",
@@ -298,75 +357,76 @@ class RevealTest {
         val skyflow = Client(skyflowConfiguration)
         val revealContainer = skyflow.container(ContainerType.REVEAL)
         val revealInput = RevealElementInput(
-            "cards",RedactionType.PLAIN_TEXT,
-            label =  "expire_date"
+            "cards", RedactionType.PLAIN_TEXT,
+            label = "expire_date"
         )
-        val revealElement = revealContainer.create(activity, revealInput, Skyflow.RevealElementOptions())
-        activity.addContentView(revealElement,layoutParams)
-        revealContainer.reveal(object: Callback {
+        val revealElement =
+            revealContainer.create(activity, revealInput, Skyflow.RevealElementOptions())
+        activity.addContentView(revealElement, layoutParams)
+        revealContainer.reveal(object : Callback {
             override fun onSuccess(responseBody: Any) {
             }
+
             override fun onFailure(exception: Any) {
                 //its valid
-            }})
+            }
+        })
     }
 
 
     @Test
-    fun testCheckRevealContainer()
-    {
+    fun testCheckRevealContainer() {
         val container = skyflow.container(ContainerType.REVEAL)
-        val collectInput = CollectElementInput("cards","card_number",
-            SkyflowElementType.CARD_NUMBER,label = "card number"
+        val collectInput = CollectElementInput(
+            "cards", "card_number",
+            SkyflowElementType.CARD_NUMBER, label = "card number"
         )
         val revealInput = RevealElementInput(
-            "51b1406a-0a30-49bf-b303-0eef66bd502d",RedactionType.PLAIN_TEXT,
-            label =  "expire_date",inputStyles = Styles()
+            "51b1406a-0a30-49bf-b303-0eef66bd502d", RedactionType.PLAIN_TEXT,
+            label = "expire_date", inputStyles = Styles()
 
         )
         val revealElement = container.create(activity, revealInput, Skyflow.RevealElementOptions())
-        junit.framework.Assert.assertEquals("51b1406a-0a30-49bf-b303-0eef66bd502d", container.revealElements[0].revealInput.token)
+        junit.framework.Assert.assertEquals(
+            "51b1406a-0a30-49bf-b303-0eef66bd502d",
+            container.revealElements[0].revealInput.token
+        )
     }
+
     @Test
-    fun testRevealElementNotMounted()
-    {
+    fun testRevealElementNotMounted() {
 
         val container = skyflow.container(ContainerType.REVEAL)
         val revealInput = RevealElementInput(
-            "51b1406a-0a30-49bf-b303-0eef66bd502d",RedactionType.PLAIN_TEXT,
-            label =  "card number",inputStyles = Styles(null)
+            "51b1406a-0a30-49bf-b303-0eef66bd502d", RedactionType.PLAIN_TEXT,
+            label = "card number", inputStyles = Styles(null)
 
         )
-        val cardNumber = container.create(activity,revealInput,RevealElementOptions())
+        val cardNumber = container.create(activity, revealInput, RevealElementOptions())
         TestCase.assertEquals(false, Utils.checkIfElementsMounted(cardNumber))
     }
 
 
     @Test
-    fun testRevealElementMounted()
-    {
+    fun testRevealElementMounted() {
 
         val container = skyflow.container(ContainerType.REVEAL)
         val revealInput = RevealElementInput(
-            "51b1406a-0a30-49bf-b303-0eef66bd502d",RedactionType.PLAIN_TEXT,
-            label =  "card number",inputStyles = Styles(null)
+            "51b1406a-0a30-49bf-b303-0eef66bd502d", RedactionType.PLAIN_TEXT,
+            label = "card number", inputStyles = Styles(null)
 
         )
-        val cardNumber = container.create(activity,revealInput)
-        activity.addContentView(cardNumber,layoutParams)
+        val cardNumber = container.create(activity, revealInput)
+        activity.addContentView(cardNumber, layoutParams)
         TestCase.assertEquals(true, Utils.checkIfElementsMounted(cardNumber))
     }
-
-
 
 
     //RevealResponse
 
     @Test
-    fun testRevealResponse()
-    {
-        val revealResponse = RevealResponse(2,object : Callback
-        {
+    fun testRevealResponse() {
+        val revealResponse = RevealResponse(2, object : Callback {
             override fun onSuccess(responseBody: Any) {
 
             }
@@ -377,36 +437,37 @@ class RevealTest {
                 TestCase.assertTrue(response.has("errors"))
             }
 
-        },LogLevel.ERROR)
+        }, LogLevel.ERROR)
 
         val successResponse = JSONObject()
         val records = JSONArray()
-        records.put(JSONObject().put("valueType","value"))
-        successResponse.put("records",records)
-        revealResponse.insertResponse(successResponse,true)
+        records.put(JSONObject().put("valueType", "value"))
+        successResponse.put("records", records)
+        revealResponse.insertResponse(successResponse, true)
 
         val failedResponse = JSONObject()
-        failedResponse.put("error","unknown error")
-        failedResponse.put("token","1234")
-        revealResponse.insertResponse(failedResponse,false)
+        failedResponse.put("error", "unknown error")
+        failedResponse.put("token", "1234")
+        revealResponse.insertResponse(failedResponse, false)
 
-        RevealResponse(1,object : Callback
-        {
+        RevealResponse(1, object : Callback {
             override fun onSuccess(responseBody: Any) {
             }
+
             override fun onFailure(exception: Any) {
-                val expectedError = SkyflowError(SkyflowErrorCode.UNKNOWN_ERROR, params =  arrayOf("Failed to reveal")).getInternalErrorMessage()
-                assertEquals(expectedError,UnitTests.getErrorMessage(exception as JSONObject))
+                val expectedError = SkyflowError(
+                    SkyflowErrorCode.UNKNOWN_ERROR,
+                    params = arrayOf("Failed to reveal")
+                ).getInternalErrorMessage()
+                assertEquals(expectedError, UnitTests.getErrorMessage(exception as JSONObject))
             }
-        },LogLevel.ERROR).insertResponse(null,false)
+        }, LogLevel.ERROR).insertResponse(null, false)
 
     }
 
     @Test
-    fun testRevealResponseNoFailedResponse()
-    {
-        val revealResponse = RevealResponse(1,object : Callback
-        {
+    fun testRevealResponseNoFailedResponse() {
+        val revealResponse = RevealResponse(1, object : Callback {
             override fun onSuccess(responseBody: Any) {
                 val response = responseBody as JSONObject
                 TestCase.assertTrue(response.has("records"))
@@ -416,20 +477,18 @@ class RevealTest {
 
             }
 
-        },LogLevel.ERROR)
+        }, LogLevel.ERROR)
 
         val successResponse = JSONObject()
         val records = JSONArray()
-        records.put(JSONObject().put("valueType","value"))
-        successResponse.put("records",records)
-        revealResponse.insertResponse(successResponse,true)
+        records.put(JSONObject().put("valueType", "value"))
+        successResponse.put("records", records)
+        revealResponse.insertResponse(successResponse, true)
     }
 
     @Test
-    fun testRevealResponseNoSuccess()
-    {
-        val revealResponse = RevealResponse(1,object : Callback
-        {
+    fun testRevealResponseNoSuccess() {
+        val revealResponse = RevealResponse(1, object : Callback {
             override fun onSuccess(responseBody: Any) {
 
             }
@@ -439,11 +498,11 @@ class RevealTest {
                 TestCase.assertTrue(response.has("errors"))
             }
 
-        },LogLevel.ERROR)
+        }, LogLevel.ERROR)
         val failedResponse = JSONObject()
-        failedResponse.put("error","unknown error")
-        failedResponse.put("token","1234")
-        revealResponse.insertResponse(failedResponse,false)
+        failedResponse.put("error", "unknown error")
+        failedResponse.put("token", "1234")
+        revealResponse.insertResponse(failedResponse, false)
     }
 
     //end RevealResponse
@@ -452,10 +511,8 @@ class RevealTest {
     //RevealResponseById
 
     @Test
-    fun testRevealResponseById()
-    {
-        val revealResponseByID = RevealResponseByID(2,object : Callback
-        {
+    fun testRevealResponseById() {
+        val revealResponseByID = RevealResponseByID(2, object : Callback {
             override fun onSuccess(responseBody: Any) {
 
             }
@@ -466,26 +523,28 @@ class RevealTest {
                 TestCase.assertTrue(response.has("errors"))
             }
 
-        },LogLevel.ERROR)
+        }, LogLevel.ERROR)
 
         val successResponse = JSONArray()
-        successResponse.put(JSONObject().put("fields","fields object"))
-        revealResponseByID.insertResponse(successResponse,true)
+        successResponse.put(JSONObject().put("fields", "fields object"))
+        revealResponseByID.insertResponse(successResponse, true)
 
         val failedResponse = JSONArray()
         val resObj = JSONObject()
-        val skyflowError = SkyflowError(SkyflowErrorCode.UNKNOWN_ERROR , logLevel = LogLevel.ERROR,params = arrayOf("unknown"))
+        val skyflowError = SkyflowError(
+            SkyflowErrorCode.UNKNOWN_ERROR,
+            logLevel = LogLevel.ERROR,
+            params = arrayOf("unknown")
+        )
         resObj.put("error", skyflowError)
         resObj.put("ids", "[\"123\",\"456\"]")
         failedResponse.put(resObj)
-        revealResponseByID.insertResponse(failedResponse,false)
+        revealResponseByID.insertResponse(failedResponse, false)
     }
 
     @Test
-    fun testRevealResponseByIdNoFailedResponse()
-    {
-        val revealResponseByID = RevealResponseByID(1,object : Callback
-        {
+    fun testRevealResponseByIdNoFailedResponse() {
+        val revealResponseByID = RevealResponseByID(1, object : Callback {
             override fun onSuccess(responseBody: Any) {
                 val response = responseBody as JSONObject
                 TestCase.assertTrue(response.has("success"))
@@ -495,18 +554,16 @@ class RevealTest {
 
             }
 
-        },LogLevel.ERROR)
+        }, LogLevel.ERROR)
 
         val successResponse = JSONArray()
-        successResponse.put(JSONObject().put("fields","fields object"))
-        revealResponseByID.insertResponse(successResponse,true)
+        successResponse.put(JSONObject().put("fields", "fields object"))
+        revealResponseByID.insertResponse(successResponse, true)
     }
 
     @Test
-    fun testRevealResponseByIdNoSuccessResponse()
-    {
-        val revealResponseByID = RevealResponseByID(1,object : Callback
-        {
+    fun testRevealResponseByIdNoSuccessResponse() {
+        val revealResponseByID = RevealResponseByID(1, object : Callback {
             override fun onSuccess(responseBody: Any) {
 
             }
@@ -516,25 +573,32 @@ class RevealTest {
                 TestCase.assertTrue(response.has("errors"))
             }
 
-        },LogLevel.ERROR)
+        }, LogLevel.ERROR)
         val failedResponse = JSONArray()
         val resObj = JSONObject()
-        val skyflowError = SkyflowError(SkyflowErrorCode.UNKNOWN_ERROR , logLevel = LogLevel.ERROR,params = arrayOf("unknown"))
+        val skyflowError = SkyflowError(
+            SkyflowErrorCode.UNKNOWN_ERROR,
+            logLevel = LogLevel.ERROR,
+            params = arrayOf("unknown")
+        )
         resObj.put("error", skyflowError)
         resObj.put("ids", "[\"123\",\"456\"]")
         failedResponse.put(resObj)
-        revealResponseByID.insertResponse(failedResponse,false)
+        revealResponseByID.insertResponse(failedResponse, false)
 
-        RevealResponseByID(1,object : Callback
-        {
+        RevealResponseByID(1, object : Callback {
             override fun onSuccess(responseBody: Any) {
             }
+
             override fun onFailure(exception: Any) {
-                val expectedError = SkyflowError(SkyflowErrorCode.UNKNOWN_ERROR, params =  arrayOf("Failed to reveal")).getInternalErrorMessage()
-                assertEquals(expectedError,UnitTests.getErrorMessage(exception as JSONObject))
+                val expectedError = SkyflowError(
+                    SkyflowErrorCode.UNKNOWN_ERROR,
+                    params = arrayOf("Failed to reveal")
+                ).getInternalErrorMessage()
+                assertEquals(expectedError, UnitTests.getErrorMessage(exception as JSONObject))
             }
 
-        },LogLevel.ERROR).insertResponse(null,false)
+        }, LogLevel.ERROR).insertResponse(null, false)
     }
     //end RevealResponseById
 
@@ -542,43 +606,49 @@ class RevealTest {
     //RevealApicallback
 
     @Test
-    fun testRevealApiCallback()
-    {
-        val apiClient = APIClient("b359c43f1b844ff4bea0f098d2c09193","https://vaulturl.com",AccessTokenProvider(),LogLevel.ERROR)
+    fun testRevealApiCallback() {
+        val apiClient = APIClient(
+            "b359c43f1b844ff4bea0f098d2c09193",
+            "https://vaulturl.com",
+            AccessTokenProvider(),
+            LogLevel.ERROR
+        )
         val revealRecords = mutableListOf<RevealRequestRecord>()
-        revealRecords.add(RevealRequestRecord("a1d84ea3-d2d4-4eeb-a21f-928ff9d01d1c","null"))
-        revealRecords.add(RevealRequestRecord("3456","null"))
+        revealRecords.add(RevealRequestRecord("a1d84ea3-d2d4-4eeb-a21f-928ff9d01d1c", "null"))
+        revealRecords.add(RevealRequestRecord("3456", "null"))
         val revealApiCallback = RevealApiCallback(object : Callback {
             override fun onSuccess(responseBody: Any) {
 
             }
 
             override fun onFailure(exception: Any) {
-                TestCase.assertEquals(SkyflowError(SkyflowErrorCode.FAILED_TO_REVEAL).getErrorMessage(),
-                    UnitTests.getErrorMessage(exception as JSONObject))
+                TestCase.assertEquals(
+                    SkyflowError(SkyflowErrorCode.FAILED_TO_REVEAL).getErrorMessage(),
+                    UnitTests.getErrorMessage(exception as JSONObject)
+                )
             }
 
-        },apiClient,records = revealRecords)
+        }, apiClient, records = revealRecords)
         revealApiCallback.onSuccess("token")
     }
 
     @Test
-    fun testOnFailedRevealApiCallback()
-    {
-        val apiClient = APIClient("1234","https://vaulturl.com",AccessTokenProvider(),LogLevel.ERROR)
+    fun testOnFailedRevealApiCallback() {
+        val apiClient =
+            APIClient("1234", "https://vaulturl.com", AccessTokenProvider(), LogLevel.ERROR)
         val revealRecords = mutableListOf<RevealRequestRecord>()
-        revealRecords.add(RevealRequestRecord("1234","null"))
-        revealRecords.add(RevealRequestRecord("3456","null"))
+        revealRecords.add(RevealRequestRecord("1234", "null"))
+        revealRecords.add(RevealRequestRecord("3456", "null"))
         val revealApiCallback = RevealApiCallback(object : Callback {
             override fun onSuccess(responseBody: Any) {
 
             }
 
             override fun onFailure(exception: Any) {
-                TestCase.assertEquals("failed",exception.toString())
+                TestCase.assertEquals("failed", exception.toString())
             }
 
-        },apiClient,records = revealRecords)
+        }, apiClient, records = revealRecords)
         revealApiCallback.onFailure("failed")
 
         RevealApiCallback(object : Callback {
@@ -590,9 +660,8 @@ class RevealTest {
                 TestCase.assertEquals("failed", UnitTests.getErrorMessage(exception as JSONObject))
             }
 
-        },apiClient,records = revealRecords).onFailure(Exception("failed"))
+        }, apiClient, records = revealRecords).onFailure(Exception("failed"))
     }
-
 
 
     //end revealapicallback
@@ -601,65 +670,66 @@ class RevealTest {
     //revealbyid callback
 
     @Test
-    fun testRevealByIdCallback()
-    {
+    fun testRevealByIdCallback() {
         val records = mutableListOf<GetByIdRecord>()
-        records.add(GetByIdRecord(arrayListOf("1234"),"cards",RedactionType.REDACTED.toString()))
-        val apiClient = APIClient("1234","https://vaulturl.com",AccessTokenProvider(),LogLevel.ERROR)
+        records.add(GetByIdRecord(arrayListOf("1234"), "cards", RedactionType.REDACTED.toString()))
+        val apiClient =
+            APIClient("1234", "https://vaulturl.com", AccessTokenProvider(), LogLevel.ERROR)
         val revealByidCallback = RevealByIdCallback(
-            object : Callback
-            {
+            object : Callback {
                 override fun onSuccess(responseBody: Any) {
 
                 }
 
                 override fun onFailure(exception: Any) {
-                    TestCase.assertEquals(SkyflowError(SkyflowErrorCode.FAILED_TO_REVEAL).getErrorMessage(),
-                        UnitTests.getErrorMessage(exception as JSONObject))
+                    TestCase.assertEquals(
+                        SkyflowError(SkyflowErrorCode.FAILED_TO_REVEAL).getErrorMessage(),
+                        UnitTests.getErrorMessage(exception as JSONObject)
+                    )
                 }
 
-            }
-            ,apiClient,records = records)
+            }, apiClient, records = records
+        )
 
         revealByidCallback.onSuccess("token")
     }
 
     @Test
-    fun testOnFailureRevealByIdCallback()
-    {
+    fun testOnFailureRevealByIdCallback() {
         val records = mutableListOf<GetByIdRecord>()
-        records.add(GetByIdRecord(arrayListOf("1234"),"cards",RedactionType.REDACTED.toString()))
-        val apiClient = APIClient("1234","https://vaulturl.com",AccessTokenProvider(),LogLevel.ERROR)
+        records.add(GetByIdRecord(arrayListOf("1234"), "cards", RedactionType.REDACTED.toString()))
+        val apiClient =
+            APIClient("1234", "https://vaulturl.com", AccessTokenProvider(), LogLevel.ERROR)
         val revealByidCallback = RevealByIdCallback(
-            object : Callback
-            {
+            object : Callback {
                 override fun onSuccess(responseBody: Any) {
 
                 }
 
                 override fun onFailure(exception: Any) {
-                    TestCase.assertEquals("failed",exception.toString())
+                    TestCase.assertEquals("failed", exception.toString())
                 }
 
-            }
-            ,apiClient,records = records)
+            }, apiClient, records = records
+        )
 
         revealByidCallback.onFailure("failed")
 
         RevealByIdCallback(
-            object : Callback
-            {
+            object : Callback {
                 override fun onSuccess(responseBody: Any) {
 
                 }
 
                 override fun onFailure(exception: Any) {
-                    TestCase.assertEquals("failed",
-                        UnitTests.getErrorMessage(exception as JSONObject))
+                    TestCase.assertEquals(
+                        "failed",
+                        UnitTests.getErrorMessage(exception as JSONObject)
+                    )
                 }
 
-            }
-            ,apiClient,records = records).onFailure(Exception("failed"))
+            }, apiClient, records = records
+        ).onFailure(Exception("failed"))
     }
 
     //end revealbyid callback
@@ -668,23 +738,23 @@ class RevealTest {
     //revealValueCallback
 
     @Test
-    fun testOnSuccessInRevealValue()
-    {
+    fun testOnSuccessInRevealValue() {
         val revealContainer = skyflow.container(ContainerType.REVEAL)
         val revealInput = RevealElementInput(
-            "51b1406a-0a30-49bf-b303-0eef66bd502d",RedactionType.PLAIN_TEXT,
-            label =  "expire_date",inputStyles = Styles()
+            "51b1406a-0a30-49bf-b303-0eef66bd502d", RedactionType.PLAIN_TEXT,
+            label = "expire_date", inputStyles = Styles()
 
         )
-        val expiry_date = revealContainer.create(activity, revealInput, Skyflow.RevealElementOptions())
+        val expiry_date =
+            revealContainer.create(activity, revealInput, Skyflow.RevealElementOptions())
         val revealInput1 = RevealElementInput(
-            "51b1406a-0a30-49bf-b303-0eef66bd502d",RedactionType.PLAIN_TEXT,
-            label =  "cvv",inputStyles = Styles()
+            "51b1406a-0a30-49bf-b303-0eef66bd502d", RedactionType.PLAIN_TEXT,
+            label = "cvv", inputStyles = Styles()
 
         )
         val cvv = revealContainer.create(activity, revealInput1, Skyflow.RevealElementOptions())
-        activity.addContentView(expiry_date,layoutParams)
-        activity.addContentView(cvv,layoutParams)
+        activity.addContentView(expiry_date, layoutParams)
+        activity.addContentView(cvv, layoutParams)
         val list = mutableListOf<Label>()
         list.add(expiry_date)
         list.add(cvv)
@@ -692,8 +762,7 @@ class RevealTest {
         val response = """
             {"records":[{"token":"51b1406a-0a30-49bf-b303-0eef66bd502d","value":"12/22"},{"token":"51b1406a-0a30-49bf-b303-0eef66bd502d","value":"123"}]}
         """.trimIndent()
-        RevealValueCallback(object : Callback
-        {
+        RevealValueCallback(object : Callback {
             override fun onSuccess(responseBody: Any) {
                 TestCase.assertTrue(JSONObject(responseBody.toString()).has("success"))
                 TestCase.assertTrue(JSONObject(responseBody.toString()).get("success") is JSONArray)
@@ -704,39 +773,40 @@ class RevealTest {
 
         }, list, skyflow.configuration.options.logLevel).onSuccess(JSONObject(response))
 
-        RevealValueCallback(object : Callback
-        {
+        RevealValueCallback(object : Callback {
             override fun onSuccess(responseBody: Any) {
             }
 
             override fun onFailure(exception: Any) {
-                val expectedError = SkyflowError(SkyflowErrorCode.UNKNOWN_ERROR, params =  arrayOf("Value not of type java.lang.String cannot be converted to JSONObject")).getInternalErrorMessage()
-                assertEquals(expectedError,UnitTests.getErrorMessage(exception as JSONObject))
+                val expectedError = SkyflowError(
+                    SkyflowErrorCode.UNKNOWN_ERROR,
+                    params = arrayOf("Value not of type java.lang.String cannot be converted to JSONObject")
+                ).getInternalErrorMessage()
+                assertEquals(expectedError, UnitTests.getErrorMessage(exception as JSONObject))
             }
         }, list, skyflow.configuration.options.logLevel).onSuccess("not json")
-
 
 
     }
 
     @Test
-    fun TestOnFailureInRevealValue()
-    {
+    fun TestOnFailureInRevealValue() {
         val revealContainer = skyflow.container(ContainerType.REVEAL)
         val revealInput = RevealElementInput(
-            "51b1406a-0a30-49bf-b303-0eef66bd502d",RedactionType.PLAIN_TEXT,
-            label =  "expire_date",inputStyles = Styles()
+            "51b1406a-0a30-49bf-b303-0eef66bd502d", RedactionType.PLAIN_TEXT,
+            label = "expire_date", inputStyles = Styles()
 
         )
-        val expiry_date = revealContainer.create(activity, revealInput, Skyflow.RevealElementOptions())
+        val expiry_date =
+            revealContainer.create(activity, revealInput, Skyflow.RevealElementOptions())
         val revealInput1 = RevealElementInput(
-            "51b1406a-0a30-49bf-b303-0eef66bd502d",RedactionType.PLAIN_TEXT,
-            label =  "cvv",inputStyles = Styles()
+            "51b1406a-0a30-49bf-b303-0eef66bd502d", RedactionType.PLAIN_TEXT,
+            label = "cvv", inputStyles = Styles()
 
         )
         val cvv = revealContainer.create(activity, revealInput1, Skyflow.RevealElementOptions())
-        activity.addContentView(expiry_date,layoutParams)
-        activity.addContentView(cvv,layoutParams)
+        activity.addContentView(expiry_date, layoutParams)
+        activity.addContentView(cvv, layoutParams)
         val list = mutableListOf<Label>()
         list.add(expiry_date)
         list.add(cvv)
@@ -744,8 +814,7 @@ class RevealTest {
         val response = """
             {"errors":[{"token":"51b1406a-0a30-49bf-b303-0eef66bd502d","value":"12/22"},{"token":"51b1406a-0a30-49bf-b303-0eef66bd502d","value":"123"}],"records":[]}
         """.trimIndent()
-        RevealValueCallback(object : Callback
-        {
+        RevealValueCallback(object : Callback {
             override fun onSuccess(responseBody: Any) {
 
             }
@@ -761,36 +830,38 @@ class RevealTest {
     }
 
     @Test
-    fun TestOnFailureInRevealValueWithoutRecords()
-    {
+    fun TestOnFailureInRevealValueWithoutRecords() {
         val revealContainer = skyflow.container(ContainerType.REVEAL)
         val revealInput = RevealElementInput(
-            "51b1406a-0a30-49bf-b303-0eef66bd502d",RedactionType.PLAIN_TEXT,
-            label =  "expire_date",inputStyles = Styles()
+            "51b1406a-0a30-49bf-b303-0eef66bd502d", RedactionType.PLAIN_TEXT,
+            label = "expire_date", inputStyles = Styles()
 
         )
-        val expiry_date = revealContainer.create(activity, revealInput, Skyflow.RevealElementOptions())
+        val expiry_date =
+            revealContainer.create(activity, revealInput, Skyflow.RevealElementOptions())
         val revealInput1 = RevealElementInput(
-            "51b1406a-0a30-49bf-b303-0eef66bd502d",RedactionType.PLAIN_TEXT,
-            label =  "cvv",inputStyles = Styles()
+            "51b1406a-0a30-49bf-b303-0eef66bd502d", RedactionType.PLAIN_TEXT,
+            label = "cvv", inputStyles = Styles()
 
         )
         val cvv = revealContainer.create(activity, revealInput1, Skyflow.RevealElementOptions())
-        activity.addContentView(expiry_date,layoutParams)
-        activity.addContentView(cvv,layoutParams)
+        activity.addContentView(expiry_date, layoutParams)
+        activity.addContentView(cvv, layoutParams)
         val list = mutableListOf<Label>()
         list.add(expiry_date)
         list.add(cvv)
 
         val response = "string"
-        RevealValueCallback(object : Callback
-        {
+        RevealValueCallback(object : Callback {
             override fun onSuccess(responseBody: Any) {
 
             }
 
             override fun onFailure(exception: Any) {
-                TestCase.assertEquals("{\"errors\":[{\"error\":\"Skyflow.SkyflowError: Interface :  - Value string of type java.lang.String cannot be converted to JSONObject\"}]}",exception.toString())
+                TestCase.assertEquals(
+                    "{\"errors\":[{\"error\":\"Skyflow.SkyflowError: Interface :  - Value string of type java.lang.String cannot be converted to JSONObject\"}]}",
+                    exception.toString()
+                )
             }
 
         }, list, skyflow.configuration.options.logLevel).onFailure(response)
@@ -798,15 +869,14 @@ class RevealTest {
     }
 
     @Test
-    fun testSetAndResetError()
-    {
+    fun testSetAndResetError() {
         val container = skyflow.container(ContainerType.REVEAL)
-        val revealInput = RevealElementInput("1234",null, )
-        val expireDate = container.create(activity,revealInput)
-        activity.addContentView(expireDate,layoutParams)
+        val revealInput = RevealElementInput("1234", null)
+        val expireDate = container.create(activity, revealInput)
+        activity.addContentView(expireDate, layoutParams)
 
         expireDate.setError("custom error")
-        assertEquals("custom error",expireDate.getErrorText())
+        assertEquals("custom error", expireDate.getErrorText())
 
         expireDate.resetError()
         assertTrue(expireDate.getErrorText().isEmpty())
@@ -817,83 +887,89 @@ class RevealTest {
     @Test
     fun testSetToken() {
         val container = skyflow.container(ContainerType.REVEAL)
-        val revealInput = RevealElementInput("1234",null, )
-        val expireDate = container.create(activity,revealInput)
+        val revealInput = RevealElementInput("1234", null)
+        val expireDate = container.create(activity, revealInput)
         expireDate.setToken("token")
-        assertEquals("token",expireDate.getToken())
+        assertEquals("token", expireDate.getToken())
     }
+
     @Test
     fun testGetToken() {
         val container = skyflow.container(ContainerType.REVEAL)
-        val revealInput = RevealElementInput("1234",null, )
-        val expireDate = container.create(activity,revealInput)
+        val revealInput = RevealElementInput("1234", null)
+        val expireDate = container.create(activity, revealInput)
         expireDate.revealInput.token = null
-        assertEquals("",expireDate.getToken())
+        assertEquals("", expireDate.getToken())
     }
+
     @Test
     fun testGetValueForConnections() {
         val container = skyflow.container(ContainerType.REVEAL)
-        val revealInput = RevealElementInput("1234",null, )
-        val expireDate = container.create(activity,revealInput)
+        val revealInput = RevealElementInput("1234", null)
+        val expireDate = container.create(activity, revealInput)
         expireDate.setToken("token")
-        assertEquals("token",expireDate.getValueForConnections())
+        assertEquals("token", expireDate.getValueForConnections())
     }
+
     @Test
     fun testGetValueForConnectionsIfActualValue() {
         val container = skyflow.container(ContainerType.REVEAL)
-        val revealInput = RevealElementInput("1234",null, )
-        val expireDate = container.create(activity,revealInput)
+        val revealInput = RevealElementInput("1234", null)
+        val expireDate = container.create(activity, revealInput)
         expireDate.setToken("token")
         expireDate.actualValue = "1234"
-        assertEquals("1234",expireDate.getValueForConnections())
+        assertEquals("1234", expireDate.getValueForConnections())
     }
+
     @Test
     fun testSetAltText() {
         val container = skyflow.container(ContainerType.REVEAL)
-        val revealInput = RevealElementInput("1234",null, )
-        val expireDate = container.create(activity,revealInput)
+        val revealInput = RevealElementInput("1234", null)
+        val expireDate = container.create(activity, revealInput)
         expireDate.setAltText("altText")
-        assertEquals("altText",expireDate.revealInput.altText)
+        assertEquals("altText", expireDate.revealInput.altText)
     }
+
     @Test
     fun testClearAltText() {
         val container = skyflow.container(ContainerType.REVEAL)
-        val revealInput = RevealElementInput("1234",null, )
-        val expireDate = container.create(activity,revealInput)
+        val revealInput = RevealElementInput("1234", null)
+        val expireDate = container.create(activity, revealInput)
         expireDate.setAltText("altText")
         expireDate.clearAltText()
-        assertEquals("",expireDate.revealInput.altText)
+        assertEquals("", expireDate.revealInput.altText)
     }
+
     @Test
     fun testClearAltTextIfActualValuePresent() {
         val container = skyflow.container(ContainerType.REVEAL)
-        val revealInput = RevealElementInput("1234",null, )
-        val expireDate = container.create(activity,revealInput)
+        val revealInput = RevealElementInput("1234", null)
+        val expireDate = container.create(activity, revealInput)
         expireDate.setAltText("altText")
         expireDate.actualValue = "1234"
         expireDate.clearAltText()
-        assertEquals("1234",expireDate.placeholder.text.toString())
+        assertEquals("1234", expireDate.placeholder.text.toString())
     }
 
     @Test
     fun testSetText() {
         val container = skyflow.container(ContainerType.REVEAL)
-        val revealInput = RevealElementInput("1234",null )
-        val expireDate = container.create(activity,revealInput)
+        val revealInput = RevealElementInput("1234", null)
+        val expireDate = container.create(activity, revealInput)
         expireDate.setText("1234")
-        assertEquals("1234",expireDate.placeholder.text.toString())
-        assertEquals("1234",expireDate.getValue())
+        assertEquals("1234", expireDate.placeholder.text.toString())
+        assertEquals("1234", expireDate.getValue())
     }
 
     @Test
     fun testSetTextIfActualValue() {
         val container = skyflow.container(ContainerType.REVEAL)
-        val revealInput = RevealElementInput("1234",null, )
-        val expireDate = container.create(activity,revealInput, RevealElementOptions("..$"))
+        val revealInput = RevealElementInput("1234", null)
+        val expireDate = container.create(activity, revealInput, RevealElementOptions("..$"))
         expireDate.setText("1234")
         expireDate.actualValue = "12345"
-        assertEquals("12345",expireDate.getValue())
-        assertEquals("1234",expireDate.placeholder.text.toString())
+        assertEquals("12345", expireDate.getValue())
+        assertEquals("1234", expireDate.placeholder.text.toString())
     }
     //end RevealValueCallback
 

--- a/Skyflow/src/test/java/com/Skyflow/SoapConnectionTest.kt
+++ b/Skyflow/src/test/java/com/Skyflow/SoapConnectionTest.kt
@@ -5,7 +5,6 @@ import Skyflow.soap.SoapApiCallback
 import Skyflow.soap.SoapConnectionConfig
 import Skyflow.soap.SoapValueCallback
 import android.app.Activity
-import android.util.Log
 import android.view.ViewGroup
 import junit.framework.Assert.*
 import org.junit.Before
@@ -22,134 +21,166 @@ import kotlin.collections.HashMap
 
 @RunWith(RobolectricTestRunner::class)
 class SoapConnectionTest {
-    lateinit var skyflow : Client
+    private lateinit var skyflow: Client
     private lateinit var activityController: ActivityController<Activity>
     private lateinit var activity: Activity
-    lateinit var layoutParams: ViewGroup.LayoutParams
+    private lateinit var layoutParams: ViewGroup.LayoutParams
 
-    var connectionUrl = "https://skyflow.com"
-    var httpHeaders = HashMap<String, String>()
-    var requestBody = ""
-    var responseBody = ""
+    private var connectionUrl = "https://skyflow.com"
+    private var httpHeaders = HashMap<String, String>()
+    private var requestBody = ""
+    private var responseBody = ""
+
     @Before
-    fun setup()
-    {
+    fun setup() {
         val configuration = Configuration(
             tokenProvider = AccessTokenProvider()
         )
         skyflow = Client(configuration)
         layoutParams = ViewGroup.LayoutParams(
             ViewGroup.LayoutParams.WRAP_CONTENT,
-            ViewGroup.LayoutParams.WRAP_CONTENT)
+            ViewGroup.LayoutParams.WRAP_CONTENT
+        )
         activityController = Robolectric.buildActivity(Activity::class.java).setup()
         activity = activityController.get()
 
     }
 
     @Test
-    fun inValidRequest()
-    {
+    fun inValidRequest() {
         val requestBody = "yyy"
-        val soapConfiguration = SoapConnectionConfig(connectionUrl,httpHeaders,requestBody,responseBody)
-        skyflow.invokeSoapConnection(soapConfiguration,object : Callback{
+        val soapConfiguration =
+            SoapConnectionConfig(connectionUrl, httpHeaders, requestBody, responseBody)
+        skyflow.invokeSoapConnection(soapConfiguration, object : Callback {
             override fun onSuccess(responseBody: Any) {
 
             }
 
             override fun onFailure(exception: Any) {
-                val skyflowError = SkyflowError(SkyflowErrorCode.INVALID_REQUEST_XML, params = arrayOf("Content is not allowed in prolog."))
-                assertEquals(skyflowError.getInternalErrorMessage(),(exception as SkyflowError).getInternalErrorMessage())
+                val skyflowError = SkyflowError(
+                    SkyflowErrorCode.INVALID_REQUEST_XML,
+                    params = arrayOf("Content is not allowed in prolog.")
+                )
+                assertEquals(
+                    skyflowError.getInternalErrorMessage(),
+                    (exception as SkyflowError).getInternalErrorMessage()
+                )
             }
 
         })
     }
 
     @Test
-    fun emptyRequest()
-    {
+    fun emptyRequest() {
         val requestBody = ""
-        val soapConfiguration = SoapConnectionConfig(connectionUrl,httpHeaders,requestBody,responseBody)
-        skyflow.invokeSoapConnection(soapConfiguration,object : Callback{
+        val soapConfiguration =
+            SoapConnectionConfig(connectionUrl, httpHeaders, requestBody, responseBody)
+        skyflow.invokeSoapConnection(soapConfiguration, object : Callback {
             override fun onSuccess(responseBody: Any) {
 
             }
 
             override fun onFailure(exception: Any) {
                 val skyflowError = SkyflowError(SkyflowErrorCode.EMPTY_REQUEST_XML)
-                assertEquals(skyflowError.getInternalErrorMessage(),(exception as SkyflowError).getInternalErrorMessage())
+                assertEquals(
+                    skyflowError.getInternalErrorMessage(),
+                    (exception as SkyflowError).getInternalErrorMessage()
+                )
             }
 
         })
     }
+
     @Test
-    fun inValidResponse()
-    {
+    fun inValidResponse() {
         val requestBody = "<a></a>"
         val responseBody = "yyy"
-        val soapConfiguration = SoapConnectionConfig(connectionUrl,httpHeaders,requestBody,responseBody)
-        skyflow.invokeSoapConnection(soapConfiguration,object : Callback{
+        val soapConfiguration =
+            SoapConnectionConfig(connectionUrl, httpHeaders, requestBody, responseBody)
+        skyflow.invokeSoapConnection(soapConfiguration, object : Callback {
             override fun onSuccess(responseBody: Any) {
 
             }
 
             override fun onFailure(exception: Any) {
-                val skyflowError = SkyflowError(SkyflowErrorCode.INVALID_RESPONSE_XML, params = arrayOf("Content is not allowed in prolog."))
-                assertEquals(skyflowError.getInternalErrorMessage().trim(),(exception as SkyflowError).getInternalErrorMessage().trim())
+                val skyflowError = SkyflowError(
+                    SkyflowErrorCode.INVALID_RESPONSE_XML,
+                    params = arrayOf("Content is not allowed in prolog.")
+                )
+                assertEquals(
+                    skyflowError.getInternalErrorMessage().trim(),
+                    (exception as SkyflowError).getInternalErrorMessage().trim()
+                )
             }
 
         })
     }
 
     @Test
-    fun invalidConnectionUrl()
-    {
+    fun invalidConnectionUrl() {
         val connectionUrl = "skyflow.com"
-        val soapConfiguration = SoapConnectionConfig(connectionUrl,httpHeaders,requestBody,responseBody)
-        skyflow.invokeSoapConnection(soapConfiguration,object : Callback{
+        val soapConfiguration =
+            SoapConnectionConfig(connectionUrl, httpHeaders, requestBody, responseBody)
+        skyflow.invokeSoapConnection(soapConfiguration, object : Callback {
             override fun onSuccess(responseBody: Any) {
 
             }
 
             override fun onFailure(exception: Any) {
-                val skyflowError = SkyflowError(SkyflowErrorCode.INVALID_CONNECTION_URL, params = arrayOf(connectionUrl))
-                assertEquals(skyflowError.getInternalErrorMessage(),(exception as SkyflowError).getInternalErrorMessage())
+                val skyflowError = SkyflowError(
+                    SkyflowErrorCode.INVALID_CONNECTION_URL,
+                    params = arrayOf(connectionUrl)
+                )
+                assertEquals(
+                    skyflowError.getInternalErrorMessage(),
+                    (exception as SkyflowError).getInternalErrorMessage()
+                )
             }
 
         })
     }
 
     @Test
-    fun testValidConnectionUrl()
-    {
+    fun testValidConnectionUrl() {
         val connectionUrl = "https://www.skyflow.com"
         requestBody = "<body></body>"
-        val soapConfiguration = SoapConnectionConfig(connectionUrl,httpHeaders,requestBody,responseBody)
-        skyflow.invokeSoapConnection(soapConfiguration,object : Callback{
+        val soapConfiguration =
+            SoapConnectionConfig(connectionUrl, httpHeaders, requestBody, responseBody)
+        skyflow.invokeSoapConnection(soapConfiguration, object : Callback {
             override fun onSuccess(responseBody: Any) {
 
             }
 
             override fun onFailure(exception: Any) {
-                val skyflowError = SkyflowError(SkyflowErrorCode.INVALID_CONNECTION_URL, params = arrayOf(connectionUrl))
-                assertEquals(skyflowError.getInternalErrorMessage(),(exception as SkyflowError).getInternalErrorMessage())
+                val skyflowError = SkyflowError(
+                    SkyflowErrorCode.INVALID_CONNECTION_URL,
+                    params = arrayOf(connectionUrl)
+                )
+                assertEquals(
+                    skyflowError.getInternalErrorMessage(),
+                    (exception as SkyflowError).getInternalErrorMessage()
+                )
             }
 
         })
     }
 
     @Test
-    fun emptyConnectionUrl()
-    {
+    fun emptyConnectionUrl() {
         val connectionUrl = ""
-        val soapConfiguration = SoapConnectionConfig(connectionUrl,httpHeaders,requestBody,responseBody)
-        skyflow.invokeSoapConnection(soapConfiguration,object : Callback{
+        val soapConfiguration =
+            SoapConnectionConfig(connectionUrl, httpHeaders, requestBody, responseBody)
+        skyflow.invokeSoapConnection(soapConfiguration, object : Callback {
             override fun onSuccess(responseBody: Any) {
 
             }
 
             override fun onFailure(exception: Any) {
                 val skyflowError = SkyflowError(SkyflowErrorCode.EMPTY_CONNECTION_URL)
-                assertEquals(skyflowError.getInternalErrorMessage(),(exception as SkyflowError).getInternalErrorMessage())
+                assertEquals(
+                    skyflowError.getInternalErrorMessage(),
+                    (exception as SkyflowError).getInternalErrorMessage()
+                )
             }
 
         })
@@ -157,132 +188,168 @@ class SoapConnectionTest {
     // soap callback
 
     @Test
-    fun invalidIdInRequest()
-    {
+    fun invalidIdInRequest() {
         val revealContainer = skyflow.container(ContainerType.REVEAL)
         val clientNodeIdInput = Skyflow.RevealElementInput(
             null, null, label = "Client Node Id", altText = "enter Client node id"
         )
         val clientNodeId = revealContainer.create(activity, clientNodeIdInput)
         val requestBody = "<skyflow>1234</skyflow>"
-        val soapConfiguration = SoapConnectionConfig(connectionUrl,httpHeaders,requestBody,responseBody)
-        val callback = SoapApiCallback(soapConfiguration,object : Callback{
+        val soapConfiguration =
+            SoapConnectionConfig(connectionUrl, httpHeaders, requestBody, responseBody)
+        val callback = SoapApiCallback(soapConfiguration, object : Callback {
             override fun onSuccess(responseBody: Any) {
 
             }
 
             override fun onFailure(exception: Any) {
-                val skyflowError = SkyflowError(SkyflowErrorCode.INVALID_ID_IN_REQUEST_XML, params = arrayOf("1234"))
-                assertEquals(skyflowError.getInternalErrorMessage(),(exception as SkyflowError).getInternalErrorMessage())
+                val skyflowError = SkyflowError(
+                    SkyflowErrorCode.INVALID_ID_IN_REQUEST_XML,
+                    params = arrayOf("1234")
+                )
+                assertEquals(
+                    skyflowError.getInternalErrorMessage(),
+                    (exception as SkyflowError).getInternalErrorMessage()
+                )
             }
 
-        },LogLevel.ERROR, client = skyflow )
-       callback.onSuccess("token")
+        }, LogLevel.ERROR, client = skyflow)
+        callback.onSuccess("token")
     }
 
     @Test
-    fun emptyIdInRequest()
-    {
+    fun emptyIdInRequest() {
         val revealContainer = skyflow.container(ContainerType.REVEAL)
         val clientNodeIdInput = Skyflow.RevealElementInput(
             null, null, label = "Client Node Id", altText = "enter Client node id"
         )
         val clientNodeId = revealContainer.create(activity, clientNodeIdInput)
         val requestBody = "<skyflow></skyflow>"
-        val soapConfiguration = SoapConnectionConfig(connectionUrl,httpHeaders,requestBody,responseBody)
-        val callback = SoapApiCallback(soapConfiguration,object : Callback{
+        val soapConfiguration =
+            SoapConnectionConfig(connectionUrl, httpHeaders, requestBody, responseBody)
+        val callback = SoapApiCallback(soapConfiguration, object : Callback {
             override fun onSuccess(responseBody: Any) {
 
             }
 
             override fun onFailure(exception: Any) {
                 val skyflowError = SkyflowError(SkyflowErrorCode.EMPTY_ID_IN_REQUEST_XML)
-                assertEquals(skyflowError.getInternalErrorMessage(),(exception as SkyflowError).getInternalErrorMessage())
+                assertEquals(
+                    skyflowError.getInternalErrorMessage(),
+                    (exception as SkyflowError).getInternalErrorMessage()
+                )
             }
 
-        },LogLevel.ERROR, client = skyflow )
+        }, LogLevel.ERROR, client = skyflow)
         callback.onSuccess("token")
     }
 
     @Test
-    fun textFieldNotMountedInRequest()
-    {
+    fun textFieldNotMountedInRequest() {
         val collectContainer = skyflow.container(ContainerType.COLLECT)
         val clientNodeIdInput = Skyflow.CollectElementInput(
-            null, null, Skyflow.SkyflowElementType.INPUT_FIELD, label = "Client Node Id", placeholder = "enter Client node id"
+            null,
+            null,
+            Skyflow.SkyflowElementType.INPUT_FIELD,
+            label = "Client Node Id",
+            placeholder = "enter Client node id"
         )
-        val clientNodeId = collectContainer.create(activity, clientNodeIdInput, CollectElementOptions(enableCardIcon = false))
+        val clientNodeId = collectContainer.create(
+            activity,
+            clientNodeIdInput,
+            CollectElementOptions(enableCardIcon = false)
+        )
         val requestBody = "<skyflow>${clientNodeId.getID()}</skyflow>"
-        val soapConfiguration = SoapConnectionConfig(connectionUrl,httpHeaders,requestBody,responseBody)
-        val callback = SoapApiCallback(soapConfiguration,object : Callback{
+        val soapConfiguration =
+            SoapConnectionConfig(connectionUrl, httpHeaders, requestBody, responseBody)
+        val callback = SoapApiCallback(soapConfiguration, object : Callback {
             override fun onSuccess(responseBody: Any) {
 
             }
 
             override fun onFailure(exception: Any) {
-                val skyflowError = SkyflowError(SkyflowErrorCode.ELEMENT_NOT_MOUNTED, params = arrayOf(clientNodeIdInput.label))
-                assertEquals(skyflowError.getInternalErrorMessage(),(exception as SkyflowError).getInternalErrorMessage())
+                val skyflowError = SkyflowError(
+                    SkyflowErrorCode.ELEMENT_NOT_MOUNTED,
+                    params = arrayOf(clientNodeIdInput.label)
+                )
+                assertEquals(
+                    skyflowError.getInternalErrorMessage(),
+                    (exception as SkyflowError).getInternalErrorMessage()
+                )
             }
 
-        },LogLevel.ERROR, client = skyflow )
+        }, LogLevel.ERROR, client = skyflow)
         callback.onSuccess("token")
     }
 
     @Test
-    fun labelNotMountedInResponse()
-    {
+    fun labelNotMountedInResponse() {
         val revealContainer = skyflow.container(ContainerType.REVEAL)
         val clientNodeIdInput = Skyflow.RevealElementInput(
             null, null, label = "Client Node Id", altText = "enter Client node id"
         )
         val clientNodeId = revealContainer.create(activity, clientNodeIdInput)
         val requestBody = "<skyflow>${clientNodeId.getID()}</skyflow>"
-        val soapConfiguration = SoapConnectionConfig(connectionUrl,httpHeaders,requestBody,responseBody)
-        val callback = SoapApiCallback(soapConfiguration,object : Callback{
+        val soapConfiguration =
+            SoapConnectionConfig(connectionUrl, httpHeaders, requestBody, responseBody)
+        val callback = SoapApiCallback(soapConfiguration, object : Callback {
             override fun onSuccess(responseBody: Any) {
 
             }
 
             override fun onFailure(exception: Any) {
-                val skyflowError = SkyflowError(SkyflowErrorCode.ELEMENT_NOT_MOUNTED, params = arrayOf(clientNodeIdInput.label))
-                assertEquals(skyflowError.getInternalErrorMessage(),(exception as SkyflowError).getInternalErrorMessage())
+                val skyflowError = SkyflowError(
+                    SkyflowErrorCode.ELEMENT_NOT_MOUNTED,
+                    params = arrayOf(clientNodeIdInput.label)
+                )
+                assertEquals(
+                    skyflowError.getInternalErrorMessage(),
+                    (exception as SkyflowError).getInternalErrorMessage()
+                )
             }
 
-        },LogLevel.ERROR, client = skyflow )
+        }, LogLevel.ERROR, client = skyflow)
         callback.onSuccess("token")
     }
 
     @Test
-    fun testCatchBlock()
-    {
-        val soapConfiguration = SoapConnectionConfig(connectionUrl,httpHeaders,requestBody,responseBody)
-        val callback = SoapApiCallback(soapConfiguration,object : Callback{
+    fun testCatchBlock() {
+        val soapConfiguration =
+            SoapConnectionConfig(connectionUrl, httpHeaders, requestBody, responseBody)
+        val callback = SoapApiCallback(soapConfiguration, object : Callback {
             override fun onSuccess(responseBody: Any) {
 
             }
 
             override fun onFailure(exception: Any) {
-                val skyflowError = SkyflowError(SkyflowErrorCode.UNKNOWN_ERROR, params = arrayOf("Index: 1, Size: 1"))
-                assertEquals(skyflowError.getInternalErrorMessage(),(exception as SkyflowError).getInternalErrorMessage())
+                val skyflowError = SkyflowError(
+                    SkyflowErrorCode.UNKNOWN_ERROR,
+                    params = arrayOf("Index: 1, Size: 1")
+                )
+                assertEquals(
+                    skyflowError.getInternalErrorMessage(),
+                    (exception as SkyflowError).getInternalErrorMessage()
+                )
             }
 
-        },LogLevel.ERROR, client = skyflow )
+        }, LogLevel.ERROR, client = skyflow)
         callback.onSuccess(true) //execute catch block
     }
 
     //soap value callback
 
     @Test
-    fun TestNormalResponse()
-    {
+    fun TestNormalResponse() {
         val revealContainer = skyflow.container(ContainerType.REVEAL)
         val clientNodeIdInput = Skyflow.RevealElementInput(
             null, null, label = "Client Node Id", altText = "enter Client node id"
         )
         val clientNodeId = revealContainer.create(activity, clientNodeIdInput)
-        val soapConfiguration = SoapConnectionConfig(connectionUrl,httpHeaders,requestBody,responseBody)
-        val callback = SoapValueCallback(skyflow,soapConfiguration,DemoCallback(),LogLevel.ERROR)
-        callback.onSuccess( """
+        val soapConfiguration =
+            SoapConnectionConfig(connectionUrl, httpHeaders, requestBody, responseBody)
+        val callback = SoapValueCallback(skyflow, soapConfiguration, DemoCallback(), LogLevel.ERROR)
+        callback.onSuccess(
+            """
                         <soapenv:Envelope>
                     <soapenv:Body>
                     <GenerateCVV>
@@ -290,12 +357,12 @@ class SoapConnectionTest {
                     </GenerateCVV>
                     </soapenv:Body>
                     </soapenv:Envelope>
-        """.trimIndent())
+        """.trimIndent()
+        )
     }
 
     @Test
-    fun testGetXmlDocumentFunction()
-    {
+    fun testGetXmlDocumentFunction() {
         val actualXml = """
                 <soapenv:Envelope>
                     <soapenv:Body>
@@ -305,17 +372,17 @@ class SoapConnectionTest {
                     </soapenv:Body>
                     </soapenv:Envelope>
         """.trimIndent()
-        val soapConfiguration = SoapConnectionConfig(connectionUrl,httpHeaders,requestBody,responseBody)
-        val callback = SoapValueCallback(skyflow,soapConfiguration,DemoCallback(),LogLevel.ERROR)
+        val soapConfiguration =
+            SoapConnectionConfig(connectionUrl, httpHeaders, requestBody, responseBody)
+        val callback = SoapValueCallback(skyflow, soapConfiguration, DemoCallback(), LogLevel.ERROR)
         val factory = DocumentBuilderFactory.newInstance()
         val builder = factory.newDocumentBuilder()
         val actualXmlDocument: Document = builder.parse(InputSource(StringReader(actualXml)))
-        assertEquals(actualXml,callback.getXmlFromDocument(actualXmlDocument))
+        assertEquals(actualXml, callback.getXmlFromDocument(actualXmlDocument))
     }
 
     @Test
-    fun testConstructLookup()
-    {
+    fun testConstructLookup() {
         val actualXml = """
                 <soapenv:Envelope>
                     <soapenv:Body>
@@ -329,19 +396,22 @@ class SoapConnectionTest {
                     </soapenv:Body>
                     </soapenv:Envelope>
         """.trimIndent()
-        val soapConfiguration = SoapConnectionConfig(connectionUrl,httpHeaders,requestBody,responseBody)
-        val callback = SoapValueCallback(skyflow,soapConfiguration,DemoCallback(),LogLevel.ERROR)
+        val soapConfiguration =
+            SoapConnectionConfig(connectionUrl, httpHeaders, requestBody, responseBody)
+        val callback = SoapValueCallback(skyflow, soapConfiguration, DemoCallback(), LogLevel.ERROR)
         val factory = DocumentBuilderFactory.newInstance()
         val builder = factory.newDocumentBuilder()
         val actualXmlDocument: Document = builder.parse(InputSource(StringReader(actualXml)))
-        callback.constructLookup(actualXmlDocument.documentElement,"")
-        assertEquals("{soapenv:Envelope.soapenv:Body.GenerateCVV=[{isFound=false, values={CVV={clientNodeId.getID()}}}]}".trim(),callback.lookup.toString().trim())
+        callback.constructLookup(actualXmlDocument.documentElement, "")
+        assertEquals(
+            "{soapenv:Envelope.soapenv:Body.GenerateCVV=[{isFound=false, values={CVV={clientNodeId.getID()}}}]}".trim(),
+            callback.lookup.toString().trim()
+        )
     }
 
 
     @Test
-    fun testAddLookupEntry()
-    {
+    fun testAddLookupEntry() {
         val actualXml = """
                 <soapenv:Envelope>
                     <soapenv:Body>
@@ -355,42 +425,45 @@ class SoapConnectionTest {
                     </soapenv:Body>
                     </soapenv:Envelope>
         """.trimIndent()
-        val soapConfiguration = SoapConnectionConfig(connectionUrl,httpHeaders,requestBody,responseBody)
-        val callback = SoapValueCallback(skyflow,soapConfiguration,DemoCallback(),LogLevel.ERROR)
+        val soapConfiguration =
+            SoapConnectionConfig(connectionUrl, httpHeaders, requestBody, responseBody)
+        val callback = SoapValueCallback(skyflow, soapConfiguration, DemoCallback(), LogLevel.ERROR)
         val factory = DocumentBuilderFactory.newInstance()
         val builder = factory.newDocumentBuilder()
         val actualXmlDocument: Document = builder.parse(InputSource(StringReader(actualXml)))
-        callback.addLookupEntry(actualXmlDocument.documentElement,"","")
-        assertEquals("{values={soapenv:Body.GenerateCVV.CVV={clientNodeId.getID()}}}".trim(),callback.lookupEntry.toString().trim())
+        callback.addLookupEntry(actualXmlDocument.documentElement, "", "")
+        assertEquals(
+            "{values={soapenv:Body.GenerateCVV.CVV={clientNodeId.getID()}}}".trim(),
+            callback.lookupEntry.toString().trim()
+        )
     }
 
     @Test
-    fun testCheckifMapIsSubSet()
-    {
-        val soapConfiguration = SoapConnectionConfig(connectionUrl,httpHeaders,requestBody,responseBody)
-        val callback = SoapValueCallback(skyflow,soapConfiguration,DemoCallback(),LogLevel.ERROR)
-        val submap = HashMap<String,String>()
-        submap.put("x","123")
-        val map = HashMap<String,String>()
+    fun testCheckifMapIsSubSet() {
+        val soapConfiguration =
+            SoapConnectionConfig(connectionUrl, httpHeaders, requestBody, responseBody)
+        val callback = SoapValueCallback(skyflow, soapConfiguration, DemoCallback(), LogLevel.ERROR)
+        val submap = HashMap<String, String>()
+        submap.put("x", "123")
+        val map = HashMap<String, String>()
         map["y"] = "123"
-        assertFalse(callback.checkIfMapIsSubset(submap,map,true))
+        assertFalse(callback.checkIfMapIsSubset(submap, map, true))
     }
 
     @Test
-    fun testCheckifMapIsSubSet2()
-    {
-        val soapConfiguration = SoapConnectionConfig(connectionUrl,httpHeaders,requestBody,responseBody)
-        val callback = SoapValueCallback(skyflow,soapConfiguration,DemoCallback(),LogLevel.ERROR)
-        val submap = HashMap<String,String>()
-        submap.put("x","123")
-        val map = HashMap<String,String>()
+    fun testCheckifMapIsSubSet2() {
+        val soapConfiguration =
+            SoapConnectionConfig(connectionUrl, httpHeaders, requestBody, responseBody)
+        val callback = SoapValueCallback(skyflow, soapConfiguration, DemoCallback(), LogLevel.ERROR)
+        val submap = HashMap<String, String>()
+        submap.put("x", "123")
+        val map = HashMap<String, String>()
         map["x"] = "123"
-        assertTrue(callback.checkIfMapIsSubset(submap,map,true))
+        assertTrue(callback.checkIfMapIsSubset(submap, map, true))
     }
 
     @Test
-    fun testConstructMap()
-    {
+    fun testConstructMap() {
         val userXml = """
                 <soapenv:Envelope>
                     <soapenv:Body>
@@ -404,18 +477,21 @@ class SoapConnectionTest {
                     </soapenv:Body>
                     </soapenv:Envelope>
         """.trimIndent()
-        val soapConfiguration = SoapConnectionConfig(connectionUrl,httpHeaders,requestBody,responseBody)
-        val callback = SoapValueCallback(skyflow,soapConfiguration,DemoCallback(),LogLevel.ERROR)
+        val soapConfiguration =
+            SoapConnectionConfig(connectionUrl, httpHeaders, requestBody, responseBody)
+        val callback = SoapValueCallback(skyflow, soapConfiguration, DemoCallback(), LogLevel.ERROR)
         val factory = DocumentBuilderFactory.newInstance()
         val builder = factory.newDocumentBuilder()
         val userDoc: Document = builder.parse(InputSource(StringReader(userXml)))
-        callback.constructMap(userDoc.documentElement,"",true)
-        assertEquals("{soapenv:Body.GenerateCVV.CVV.Skyflow=id}".trim(),callback.tempMap.toString().trim())
+        callback.constructMap(userDoc.documentElement, "", true)
+        assertEquals(
+            "{soapenv:Body.GenerateCVV.CVV.Skyflow=id}".trim(),
+            callback.tempMap.toString().trim()
+        )
     }
 
     @Test
-    fun testNewHelper()
-    {
+    fun testNewHelper() {
         val responseBody = """
                 <soapenv:Envelope>
                     <soapenv:Body>
@@ -442,12 +518,14 @@ class SoapConnectionTest {
                     </soapenv:Body>
                     </soapenv:Envelope>
         """.trimIndent()
-        val soapConfiguration = SoapConnectionConfig(connectionUrl,httpHeaders,requestBody,responseBody)
-        val callback = SoapValueCallback(skyflow,soapConfiguration,DemoCallback(),LogLevel.ERROR)
+        val soapConfiguration =
+            SoapConnectionConfig(connectionUrl, httpHeaders, requestBody, responseBody)
+        val callback = SoapValueCallback(skyflow, soapConfiguration, DemoCallback(), LogLevel.ERROR)
         callback.onSuccess(actualXml)
-        assertEquals("{}",callback.actualValues.toString())
+        assertEquals("{}", callback.actualValues.toString())
     }
 }
+
 class DemoCallback : Callback {
     override fun onSuccess(responseBody: Any) {
     }


### PR DESCRIPTION
## Set Token Not Behaving Properly in Android SDK

- Fixed the bug where if token was not provided in constructor for reveal elements, `setToken` method wasn't working.
- Issue [SK-536](https://skyflow.atlassian.net/browse/SK-536)

[SK-536]: https://skyflow.atlassian.net/browse/SK-536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ