### PR TITLE
Remove static white background color on TextField

### DIFF
--- a/Skyflow/.project
+++ b/Skyflow/.project
@@ -22,12 +22,12 @@
 	</natures>
 	<filteredResources>
 		<filter>
-			<id>1630914164312</id>
+			<id>1683819466808</id>
 			<name></name>
 			<type>30</type>
 			<matcher>
 				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
 			</matcher>
 		</filter>
 	</filteredResources>

--- a/Skyflow/src/main/kotlin/Skyflow/TextField.kt
+++ b/Skyflow/src/main/kotlin/Skyflow/TextField.kt
@@ -128,10 +128,10 @@ class TextField @JvmOverloads constructor(
     private fun buildTextField()
     {
         state = StateforText(this)
-        border.setColor(Color.WHITE)
+        border.setColor(Color.TRANSPARENT)
         border.setStroke(collectInput.inputStyles.base.borderWidth,collectInput.inputStyles.base.borderColor)
         border.cornerRadius = collectInput.inputStyles.base.cornerRadius
-        //inputField.setBackgroundDrawable(border)
+        inputField.setBackgroundDrawable(border)
         inputField.setPadding(padding.left,padding.top,padding.right,padding.bottom)
         inputField.gravity = collectInput.inputStyles.base.textAlignment
         inputField.hint = collectInput.placeholder

--- a/Skyflow/src/main/kotlin/Skyflow/TextField.kt
+++ b/Skyflow/src/main/kotlin/Skyflow/TextField.kt
@@ -128,7 +128,7 @@ class TextField @JvmOverloads constructor(
     private fun buildTextField()
     {
         state = StateforText(this)
-        border.setColor(Color.WHITE)
+        border.setColor(Color.MAGENTA)
         border.setStroke(collectInput.inputStyles.base.borderWidth,collectInput.inputStyles.base.borderColor)
         border.cornerRadius = collectInput.inputStyles.base.cornerRadius
         inputField.setBackgroundDrawable(border)

--- a/Skyflow/src/main/kotlin/Skyflow/TextField.kt
+++ b/Skyflow/src/main/kotlin/Skyflow/TextField.kt
@@ -128,10 +128,10 @@ class TextField @JvmOverloads constructor(
     private fun buildTextField()
     {
         state = StateforText(this)
-        border.setColor(Color.MAGENTA)
+        border.setColor(Color.WHITE)
         border.setStroke(collectInput.inputStyles.base.borderWidth,collectInput.inputStyles.base.borderColor)
         border.cornerRadius = collectInput.inputStyles.base.cornerRadius
-        inputField.setBackgroundDrawable(border)
+        //inputField.setBackgroundDrawable(border)
         inputField.setPadding(padding.left,padding.top,padding.right,padding.bottom)
         inputField.gravity = collectInput.inputStyles.base.textAlignment
         inputField.hint = collectInput.placeholder


### PR DESCRIPTION
It is impossible to change the background color of the TextField because there is an hardcoded white background drawable set.
This pull request set it to transparent so that the setBackgoundColor works again