### PR TITLE
SK-1597 Implement card brand choice for Card Number Element

### DIFF
--- a/Skyflow/src/main/kotlin/Skyflow/CardMetadata.kt
+++ b/Skyflow/src/main/kotlin/Skyflow/CardMetadata.kt
@@ -1,0 +1,7 @@
+package Skyflow
+
+import Skyflow.collect.elements.utils.CardType
+
+class CardMetadata(var scheme: Array<CardType>) {
+
+}

--- a/Skyflow/src/main/kotlin/Skyflow/CollectElementOptions.kt
+++ b/Skyflow/src/main/kotlin/Skyflow/CollectElementOptions.kt
@@ -5,7 +5,8 @@ class CollectElementOptions(
     var enableCardIcon: Boolean = true,
     var format: String = "",
     var translation: HashMap<Char, String>? = null,
-    val enableCopy: Boolean = false
+    val enableCopy: Boolean = false,
+    var cardMetadata: CardMetadata = CardMetadata(arrayOf())
 ) {
     internal var inputFormat: HashMap<Char, Regex> = hashMapOf()
     private val HYPHEN_CARD_NUMBER_FORMAT = "XXXX-XXXX-XXXX-XXXX"

--- a/Skyflow/src/main/kotlin/Skyflow/TextField.kt
+++ b/Skyflow/src/main/kotlin/Skyflow/TextField.kt
@@ -12,7 +12,9 @@ import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
 import android.graphics.Typeface
+import android.graphics.drawable.Drawable
 import android.graphics.drawable.GradientDrawable
+import android.graphics.drawable.LayerDrawable
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
@@ -21,14 +23,18 @@ import android.text.InputFilter.LengthFilter
 import android.text.style.ForegroundColorSpan
 import android.util.AttributeSet
 import android.view.KeyEvent
+import android.view.Menu
+import android.view.MenuItem
 import android.view.MotionEvent
 import android.view.View
 import android.view.View.OnFocusChangeListener
 import android.view.animation.Animation
 import android.view.animation.AnimationUtils
 import android.widget.EditText
+import android.widget.PopupMenu
 import android.widget.TextView
 import androidx.annotation.RequiresApi
+import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.text.isDigitsOnly
 import com.Skyflow.collect.elements.validations.*
@@ -76,6 +82,11 @@ class TextField @JvmOverloads constructor(
     private lateinit var labelLP: LayoutParams
     private lateinit var errorLP: LayoutParams
 
+    internal var cardType = CardType.EMPTY
+    private var dAWidth = 0
+    private var cIWidth = 0
+    private var isCustomCardBrandSelected = false
+
     internal fun applyCallback(eventName: ComposableEvents, handler: (() -> Unit)) {
         when (eventName) {
             ComposableEvents.ON_FOCUS_IS_TRUE -> this.onFocusIsTrue = handler
@@ -84,8 +95,8 @@ class TextField @JvmOverloads constructor(
         }
     }
 
-    private var drawableRight = 0
-    private var drawableLeft = 0
+    private var drawableRight: Drawable? = null
+    private var drawableLeft: Drawable? = null
 
     override var uuid = ""
     override fun getValue(): String {
@@ -128,9 +139,9 @@ class TextField @JvmOverloads constructor(
     }
 
     private fun appendIcon(iconName: String) {
-        var drawableIcon = 0
-        val copyIcon = R.drawable.ic_copy
-        val copiedIcon = R.drawable.ic_copied
+        var drawableIcon: Drawable? = null
+        val copyIcon = ContextCompat.getDrawable(this.context, R.drawable.ic_copy)
+        val copiedIcon = ContextCompat.getDrawable(this.context, R.drawable.ic_copied)
 
         when (iconName) {
             "COPY" -> {
@@ -141,26 +152,32 @@ class TextField @JvmOverloads constructor(
                 Handler(Looper.getMainLooper()).postDelayed({
                     inputField.setCompoundDrawablesRelativeWithIntrinsicBounds(
                         drawableLeft,
-                        0,
+                        null,
                         copyIcon,
-                        0
+                        null
                     )
                     drawableIcon = copyIcon
                 }, 2000) // 2000 milliseconds = 2 seconds
             }
         }
-        inputField.setCompoundDrawablesRelativeWithIntrinsicBounds(drawableLeft, 0, drawableIcon, 0)
+        inputField.setCompoundDrawablesRelativeWithIntrinsicBounds(
+            drawableLeft,
+            null,
+            drawableIcon,
+            null
+        )
         inputField.compoundDrawablePadding = 8
         drawableRight = drawableIcon
     }
 
     private fun removeIcon() {
-        inputField.setCompoundDrawablesRelativeWithIntrinsicBounds(drawableLeft, 0, 0, 0)
+        drawableRight = null
+        inputField.setCompoundDrawablesRelativeWithIntrinsicBounds(drawableLeft, null, null, null)
     }
 
     private fun performCopyAction(event: MotionEvent): Boolean {
         val actionX = event.rawX
-        if (drawableRight != 0) {
+        if (drawableRight !== null) {
             val wBound = inputField.right - inputField.compoundDrawables[2].bounds.width()
             if (actionX >= wBound && actionX <= inputField.right) {
                 handleTap()
@@ -285,6 +302,11 @@ class TextField @JvmOverloads constructor(
         this.setupField(this.collectInput, this.options)
     }
 
+    fun update(updateCollectOptions: CollectElementOptions) {
+        this.options.cardMetadata = updateCollectOptions.cardMetadata
+        this.setupField(this.collectInput, this.options)
+    }
+
     @RequiresApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
     public override fun onAttachedToWindow() {
         super.onAttachedToWindow()
@@ -320,10 +342,13 @@ class TextField @JvmOverloads constructor(
                     return
                 }
                 actualValue = inputField.text.toString()
+                if (actualValue.isEmpty()) {
+                    updateCardChoice(CardType.EMPTY, false)
+                }
                 formatPatternForField(s)
                 state = StateforText(this@TextField)
                 if (state.getInternalState().getBoolean("isValid")) {
-                    if (options.enableCopy) {
+                    if (options.enableCopy && actualValue.isNotEmpty()) {
                         appendIcon("COPY")
                     }
                 } else if (options.enableCopy) {
@@ -363,10 +388,11 @@ class TextField @JvmOverloads constructor(
             false
         }
 
-        inputField.setOnTouchListener { _, event ->
+        inputField.setOnTouchListener { view, event ->
             when (event?.action) {
                 MotionEvent.ACTION_DOWN -> {
                     performCopyAction(event)
+                    showCardBrandChoices(event, view)
                 }
             }
             false
@@ -374,14 +400,62 @@ class TextField @JvmOverloads constructor(
     }
 
     private fun changeCardIcon(cardType: CardType) {
+        val dropdownArrow = ContextCompat.getDrawable(this.context, R.drawable.ic_dropdown)
+        val cardImage = ContextCompat.getDrawable(this.context, cardType.image)
+
+        dAWidth = dropdownArrow?.intrinsicWidth ?: 0
+        cIWidth = cardImage?.intrinsicWidth ?: 0
+
+        var icons = arrayOf(cardImage)
+        var layerDrawable = LayerDrawable(icons)
+        if (options.cardMetadata.scheme.size > 1) {
+            icons = arrayOf(cardImage, dropdownArrow)
+            layerDrawable = LayerDrawable(icons)
+            layerDrawable.setLayerInset(0, 0, 0, dAWidth, 0)
+            layerDrawable.setLayerInset(1, cIWidth, 0, 0, 0)
+        }
+        drawableLeft = layerDrawable
+
         inputField.setCompoundDrawablesRelativeWithIntrinsicBounds(
-            cardType.image,
-            0,
+            drawableLeft,
+            null,
             drawableRight,
-            0
+            null
         )
         inputField.compoundDrawablePadding = 8
-        drawableLeft = cardType.image
+    }
+
+    private fun showCardBrandChoices(event: MotionEvent, view: View): Boolean {
+        val popupMenu = PopupMenu(context, view)
+
+        val cardChoices = options.cardMetadata.scheme
+        cardChoices.forEach {
+            popupMenu.menu.add(Menu.NONE, it.ordinal, Menu.NONE, it.defaultName)
+        }
+
+        popupMenu.setOnMenuItemClickListener { menuItem: MenuItem ->
+            val selectedCardType = CardType.getCardType(menuItem.title.toString())
+            updateCardChoice(selectedCardType, true)
+            changeCardIcon(selectedCardType)
+            inputField.setSelection(inputField.length())
+            true
+        }
+
+        val actionX = event.rawX
+        if (drawableLeft != null) {
+            val wBound = inputField.left + inputField.compoundDrawables[0].bounds.width()
+            if (actionX >= inputField.left && actionX <= wBound) {
+                popupMenu.show()
+                return true
+            }
+        }
+        return false
+    }
+
+    private fun updateCardChoice(selectedCardType: CardType, customCardSelected: Boolean) {
+        cardType = selectedCardType
+        isCustomCardBrandSelected = customCardSelected
+        state = StateforText(this@TextField)
     }
 
     private fun applyLabelStyle(style: Style) {
@@ -540,7 +614,10 @@ class TextField @JvmOverloads constructor(
     private fun formatPatternForField(s: Editable?) {
         when (fieldType) {
             SkyflowElementType.CARD_NUMBER -> {
-                val cardType = CardType.forCardNumber(inputField.text.toString())
+                cardType = if (!isCustomCardBrandSelected) {
+                    CardType.forCardNumber(inputField.text.toString())
+                } else cardType
+
                 val separator = options.parseFormatForSeparator()
 
                 if (options.enableCardIcon) {

--- a/Skyflow/src/main/kotlin/Skyflow/collect/elements/utils/CardType.kt
+++ b/Skyflow/src/main/kotlin/Skyflow/collect/elements/utils/CardType.kt
@@ -17,7 +17,7 @@ enum class  CardType (var defaultName:String,var regex: String,var cardLength:In
         "Visa" , "^4\\d*", intArrayOf(13,16), intArrayOf(4,8,12),
         3, SecurityCode.cvv.rawValue, R.drawable.ic_visa),
     MASTERCARD(
-        "MasterCard","^(5[1-5]|222[1-9]|22[3-9]|2[3-6]|27[0-1]|2720)\\d*",
+        "Mastercard","^(5[1-5]|222[1-9]|22[3-9]|2[3-6]|27[0-1]|2720)\\d*",
         intArrayOf(16),intArrayOf(4,8,12),
         3,  SecurityCode.cvc.rawValue, R.drawable.ic_mastercard),
     DISCOVER(
@@ -29,11 +29,11 @@ enum class  CardType (var defaultName:String,var regex: String,var cardLength:In
         intArrayOf(15),intArrayOf(4,10),
         4, SecurityCode.cid.rawValue, R.drawable.ic_amex),
     DINERS_CLUB(
-        "Diners Club","^(36|38|30[0-5])\\d*",
+        "DinersClub","^(36|38|30[0-5])\\d*",
         intArrayOf(14,15,16,17,18,19),intArrayOf(4,10),
         3, SecurityCode.cvv.rawValue, R.drawable.ic_diners),
     JCB(
-        "JCB","^35\\d*",
+        "Jcb","^35\\d*",
         intArrayOf(16,17,18,19),intArrayOf(4,8,12,16),
         3, SecurityCode.cvv.rawValue, R.drawable.ic_jcb),
     MAESTRO(
@@ -41,13 +41,16 @@ enum class  CardType (var defaultName:String,var regex: String,var cardLength:In
         intArrayOf(12,13,14,15,16,17,18,19),intArrayOf(4,8,12,16),
         3, SecurityCode.cvc.rawValue, R.drawable.ic_maestro),
     UNIONPAY(
-        "UnionPay","^62\\d*",
+        "Unionpay","^62\\d*",
         intArrayOf(16,17,18,19),intArrayOf(4,8,12,16),
         3, SecurityCode.cvn.rawValue, R.drawable.ic_unionpay),
     HIPERCARD(
-        "HiperCard","^606282\\d*",
+        "Hipercard","^606282\\d*",
         intArrayOf(14,15,16,17,18,19),intArrayOf(4,8,12,16),
         3, SecurityCode.cvc.rawValue, R.drawable.ic_hypercard),
+    CARTES_BANCAIRES("Cartes Bancaires", "^4\\d*",
+        intArrayOf(13,16), intArrayOf(4,8,12), 3,
+        SecurityCode.cvv.rawValue, R.drawable.ic_cartes_bancaires),
     UNKNOWN(
         "Unknown","\\d+",
         intArrayOf(8,9,10,11,12,13,14,15,16,17,18,19),intArrayOf(4,8,12,16),
@@ -101,6 +104,16 @@ enum class  CardType (var defaultName:String,var regex: String,var cardLength:In
                 }
             }
             return result
+        }
+
+        internal fun getCardType(name: String): CardType {
+            val cards = enumValues<CardType>()
+            cards.forEach {
+                if (it.defaultName == name) {
+                    return it
+                }
+            }
+            return UNKNOWN
         }
     }
     open fun getSpaceIndices(): IntArray {

--- a/Skyflow/src/main/kotlin/Skyflow/core/elements/state/StateforText.kt
+++ b/Skyflow/src/main/kotlin/Skyflow/core/elements/state/StateforText.kt
@@ -16,6 +16,7 @@ class StateforText internal constructor(val tf: TextField) : State(tf.columnName
     var validationError: SkyflowValidationError = ""
     var isFocused: Boolean = false
     var fieldType: SkyflowElementType
+    var selectedCardScheme: String
 
     init {
         validationError = tf.validate()
@@ -24,6 +25,12 @@ class StateforText internal constructor(val tf: TextField) : State(tf.columnName
         inputLength = tf.inputField.length()
         isFocused = tf.inputField.hasFocus()
         fieldType = tf.collectInput.type
+        selectedCardScheme = getCardSchemeString()
+    }
+
+    private fun getCardSchemeString(): String {
+        return if (tf.cardType === CardType.EMPTY) ""
+        else tf.cardType.toString()
     }
 
     override fun show(): String {
@@ -34,6 +41,7 @@ class StateforText internal constructor(val tf: TextField) : State(tf.columnName
                 "isEmpty": $isEmpty,
                 "validationErrors": $validationError,
                 "inputLength": $inputLength
+                "selectedCardScheme": $selectedCardScheme
             }
         """
     }
@@ -49,6 +57,7 @@ class StateforText internal constructor(val tf: TextField) : State(tf.columnName
         result.put("inputLength", inputLength)
         result.put("validationError", validationError)
         result.put("isFocused", isFocused)
+        result.put("selectedCardScheme", selectedCardScheme)
 
         return result
     }
@@ -60,6 +69,7 @@ class StateforText internal constructor(val tf: TextField) : State(tf.columnName
         state.put("isRequired", isRequired)
         state.put("isFocused", isFocused)
         state.put("isValid", isValid)
+        state.put("selectedCardScheme", selectedCardScheme)
         var value = ""
         if (env == Env.DEV) {
             value = tf.getValue()

--- a/Skyflow/src/main/res/drawable/ic_cartes_bancaires.xml
+++ b/Skyflow/src/main/res/drawable/ic_cartes_bancaires.xml
@@ -1,0 +1,45 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:width="39dp"
+    android:height="24dp"
+    android:viewportWidth="26.47"
+    android:viewportHeight="18.16">
+  <path
+      android:pathData="M0,0h26.47v18.16H0z"
+      android:fillColor="#29abe2"/>
+  <path
+      android:pathData="M0,0h26.47v18.16H0z">
+    <aapt:attr name="android:fillColor">
+      <gradient 
+          android:centerX="1.47"
+          android:centerY="17.674"
+          android:gradientRadius="26.83"
+          android:type="radial">
+        <item android:offset="0.09" android:color="#FF009245"/>
+        <item android:offset="0.23" android:color="#E2049552"/>
+        <item android:offset="0.52" android:color="#960D9E74"/>
+        <item android:offset="0.91" android:color="#1E1BACAB"/>
+        <item android:offset="1" android:color="#001FB0B8"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+  <path
+      android:pathData="M0,0h26.47v18.16H0z">
+    <aapt:attr name="android:fillColor">
+      <gradient 
+          android:centerX="5.89"
+          android:centerY="19.23"
+          android:gradientRadius="34.42"
+          android:type="radial">
+        <item android:offset="0.15" android:color="#001FB0B8"/>
+        <item android:offset="0.35" android:color="#661C7491"/>
+        <item android:offset="0.56" android:color="#BA1A4471"/>
+        <item android:offset="0.74" android:color="#ED18265E"/>
+        <item android:offset="0.87" android:color="#FF181B57"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+  <path
+      android:pathData="M14.39,3.86h7.07a2.47,2.47 0,0 1,2.47 2.47,2.47 2.47,0 0,1 -2.47,2.47h-7.07V3.86zM14.39,9.36h7.07a2.47,2.47 0,0 1,2.47 2.47,2.47 2.47,0 0,1 -2.47,2.47h-7.07V9.36zM8.23,9.36V8.8h5.69a5.51,5.51 0,0 0,-5.69 -4.94,5.47 5.47,0 0,0 -5.69,5.22 5.47,5.47 0,0 0,5.69 5.22,5.51 5.51,0 0,0 5.69,-4.94z"
+      android:fillColor="#fff"/>
+</vector>

--- a/Skyflow/src/main/res/drawable/ic_dropdown.xml
+++ b/Skyflow/src/main/res/drawable/ic_dropdown.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#070707"
+    android:alpha="0.8">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M7.41,8.59L12,13.17l4.59,-4.58L18,10l-6,6 -6,-6 1.41,-1.41z"/>
+</vector>

--- a/Skyflow/src/test/java/com/Skyflow/CollectTest.kt
+++ b/Skyflow/src/test/java/com/Skyflow/CollectTest.kt
@@ -3,6 +3,8 @@ package com.Skyflow
 import Skyflow.*
 import Skyflow.collect.client.CollectAPICallback
 import Skyflow.collect.client.CollectRequestBody
+import Skyflow.collect.elements.utils.Card
+import Skyflow.collect.elements.utils.CardType
 import Skyflow.collect.elements.validations.ElementValueMatchRule
 import Skyflow.core.APIClient
 import Skyflow.core.elements.state.StateforText
@@ -22,6 +24,7 @@ import org.robolectric.android.controller.ActivityController
 import java.io.IOException
 import android.util.Log
 import android.view.Gravity
+import android.view.MotionEvent
 import com.Skyflow.collect.elements.validations.ValidationSet
 //import junit.framework.Assert
 //import junit.framework.Assert.*
@@ -38,6 +41,12 @@ class CollectTest {
     private lateinit var activityController: ActivityController<Activity>
     private lateinit var activity: Activity
     lateinit var layoutParams: ViewGroup.LayoutParams
+
+    private fun getCardSchemes(len: Int): Array<CardType> {
+        return if (len < 8) arrayOf(CardType.CARTES_BANCAIRES)
+        else arrayOf(CardType.CARTES_BANCAIRES, CardType.MASTERCARD)
+    }
+
 
     @Before
     fun setup() {
@@ -1544,6 +1553,36 @@ class CollectTest {
         Assert.assertEquals(15, cardNumber.inputField.paddingBottom)
         Assert.assertEquals(Color.parseColor("#eeaaee"), cardNumber.inputField.currentHintTextColor)
         Assert.assertEquals(Color.GREEN, cardNumber.inputField.currentTextColor)
+    }
+
+    @Test
+    fun testUpdateCollectElementOptions() {
+        val container = skyflow.container(ContainerType.COLLECT)
+        val collectInput = CollectElementInput(
+            table = "cards",
+            column = "card_number",
+            type = SkyflowElementType.CARD_NUMBER,
+            placeholder = "XXXX"
+        )
+        val options = CollectElementOptions(required = true, enableCopy = true)
+        val cardNumber = container.create(activity, collectInput, options)
+        cardNumber.onAttachedToWindow()
+
+        cardNumber.on(EventName.CHANGE) { state ->
+            val value = state.get("value")
+            val cards = getCardSchemes(value.toString().length)
+            cardNumber.update(CollectElementOptions(cardMetadata = CardMetadata(cards)))
+        }
+
+        var state = StateforText(cardNumber)
+        Assert.assertTrue(state.getInternalState().getBoolean("isRequired"))
+        Assert.assertNull(cardNumber.inputField.compoundDrawablesRelative[2])
+
+        cardNumber.setText("5428480012345671")
+        state = StateforText(cardNumber)
+        Assert.assertTrue(state.getInternalState().getBoolean("isRequired"))
+        Assert.assertNotNull(cardNumber.inputField.compoundDrawablesRelative[2])
+        Assert.assertEquals(CardType.MASTERCARD, cardNumber.cardType)
     }
 }
 

--- a/Skyflow/src/test/java/com/Skyflow/UnitTests.kt
+++ b/Skyflow/src/test/java/com/Skyflow/UnitTests.kt
@@ -877,14 +877,16 @@ class UnitTests {
             "cards", "card_number",
             SkyflowElementType.INPUT_FIELD, placeholder = "card number"
         )
-        val first_name = container.create(activity, collectInput) as TextField
-        activity.addContentView(first_name, layoutParams)
-        val stateforText = StateforText(first_name)
-        assertTrue(stateforText.isEmpty)
-        assertTrue(stateforText.isValid)
-        assertFalse(stateforText.isFocused)
-        assertEquals(0, stateforText.inputLength)
-        assertEquals(SkyflowElementType.INPUT_FIELD, stateforText.fieldType)
+        val firstName = container.create(activity, collectInput) as TextField
+        activity.addContentView(firstName, layoutParams)
+        val stateForText = StateforText(firstName)
+        assertTrue(stateForText.isEmpty)
+        assertTrue(stateForText.isValid)
+        assertFalse(stateForText.isFocused)
+        assertEquals(0, stateForText.inputLength)
+        assertEquals(SkyflowElementType.INPUT_FIELD, stateForText.fieldType)
+        assertEquals(String(), stateForText.validationError)
+        assertEquals(String(), stateForText.selectedCardScheme)
     }
 
     @Test
@@ -1632,7 +1634,7 @@ class UnitTests {
         val cardNumber2 = "5454422955385717"
         cardtype = CardType.forCardNumber(cardNumber2)
         assertTrue(cardtype.equals(CardType.MASTERCARD))
-        assertTrue(cardtype.defaultName.equals("MasterCard"))
+        assertTrue(cardtype.defaultName.equals("Mastercard"))
         assertTrue(cardtype.image.equals(R.drawable.ic_mastercard))
 
         val cardNumber3 = "11111"
@@ -1952,6 +1954,12 @@ class UnitTests {
 
         val actualMetrics = Utils.fetchMetrics()
         Assert.assertEquals(expectedMetrics.toString(), actualMetrics.toString())
+    }
+
+    @Test
+    fun testCardMetadata() {
+        val cardMetadata = CardMetadata(arrayOf(CardType.MASTERCARD, CardType.CARTES_BANCAIRES))
+        Assert.assertEquals(2, cardMetadata.scheme.size)
     }
 }
 


### PR DESCRIPTION
### Why
- For EU regulations, merchants need to provide their users an option to select the card provider in case of `co-badged` cards.
- To be compliant, we are adding card brand choice support for our Card Number element.

### Goal
- To be compliant with EU regulations,
- Offer users the ability to select the card provider via a drop-down in case of `co-badged` cards

### Testing
- Have done manual testing of the feature under different scenarios
- Added unit tests to cover the scenarios. Flow will be covered in E2E tests.