### PR TITLE
SK-1951 Add card brand choice enhancements

### DIFF
--- a/Skyflow/src/main/kotlin/Skyflow/TextField.kt
+++ b/Skyflow/src/main/kotlin/Skyflow/TextField.kt
@@ -162,6 +162,7 @@ class TextField @JvmOverloads constructor(
                         null
                     )
                     drawableIcon = copyIcon
+                    drawableRight = drawableIcon
                 }, 2000) // 2000 milliseconds = 2 seconds
             }
         }
@@ -319,9 +320,13 @@ class TextField @JvmOverloads constructor(
         isCardMetadataUpdated = true
         this.options.cardMetadata = updateCollectOptions.cardMetadata
         this.setupField(this.collectInput, this.options)
-        if (updateCollectOptions.cardMetadata.scheme.size < 2) {
-            invokeUserOnChangeListener()
-        }
+
+        val defaultCardType = if (this.options.cardMetadata.scheme.size > 1)
+            this.options.cardMetadata.scheme[0]
+        else cardType
+        updateCardChoice(defaultCardType, true)
+        changeCardIcon(defaultCardType)
+        invokeUserOnChangeListener()
     }
 
     @RequiresApi(Build.VERSION_CODES.JELLY_BEAN_MR1)

--- a/Skyflow/src/test/java/com/Skyflow/CollectTest.kt
+++ b/Skyflow/src/test/java/com/Skyflow/CollectTest.kt
@@ -1584,10 +1584,16 @@ class CollectTest {
         val cardNumber = container.create(activity, collectInput, options)
         cardNumber.onAttachedToWindow()
 
+        var scheme = arrayOf<CardType>()
         cardNumber.on(EventName.CHANGE) { state ->
-            val value = state.get("value")
-            val cards = getCardSchemes(value.toString().length)
-            cardNumber.update(CollectElementOptions(cardMetadata = CardMetadata(cards)))
+            val value = state.getString("value")
+            if (value.length < 8 && scheme.isNotEmpty()) {
+                scheme = arrayOf(CardType.CARTES_BANCAIRES)
+                cardNumber.update(CollectElementOptions(cardMetadata = CardMetadata(scheme)))
+            } else if (value.length >= 8 && scheme.isEmpty()) {
+                scheme = getCardSchemes(value.length)
+                cardNumber.update(CollectElementOptions(cardMetadata = CardMetadata(scheme)))
+            }
         }
 
         var state = StateforText(cardNumber)
@@ -1598,7 +1604,7 @@ class CollectTest {
         state = StateforText(cardNumber)
         Assert.assertTrue(state.getInternalState().getBoolean("isRequired"))
         Assert.assertNotNull(cardNumber.inputField.compoundDrawablesRelative[2])
-        Assert.assertEquals(CardType.MASTERCARD, cardNumber.cardType)
+        Assert.assertEquals(CardType.CARTES_BANCAIRES, cardNumber.cardType)
     }
 }
 


### PR DESCRIPTION
This PR contains changes for enhancing card brand choice behaviour
## Why
- The card brand choice behaviour required some enhancements.
- Now, the card icon for first option provided in `scheme` will be rendered in UI.

## Goal
- This gives the flexibility to control the overall UX of card brand choice selection to the users.

## Testing
- Tested the changes manually
- Modified existing unit tests to cover new changes