### PR TITLE
SK-1990/Release/25.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
+
 ## [1.25.2] - 2025-04-14
 ### Added
 - Flexibility to display the desired card brand scheme for card brand choice.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.25.2] - 2025-04-14
+### Added
+- Flexibility to display the desired card brand scheme for card brand choice.
+
 ## [1.25.1] - 2025-01-09
 ### Fixed
 - Fixed `onChange` listener not firing in card brand choice dropdown selection.

--- a/Skyflow/build.gradle
+++ b/Skyflow/build.gradle
@@ -10,7 +10,7 @@ ext {
     mGroupId = "com.skyflowapi.android"
     mArtifactId = "skyflow-android-sdk"
     mVersionCode = 1
-    mVersionName = "1.25.1"
+    mVersionName = "1.25.1-dev.5d01a73"
 
     mLibraryName = "skyflow-android"
     mLibraryDescription = "Skyflow’s android SDK can be used to securely collect, tokenize, and display sensitive data in the mobile without exposing your front-end infrastructure to sensitive data."

--- a/Skyflow/build.gradle
+++ b/Skyflow/build.gradle
@@ -10,7 +10,7 @@ ext {
     mGroupId = "com.skyflowapi.android"
     mArtifactId = "skyflow-android-sdk"
     mVersionCode = 1
-    mVersionName = "1.25.1-dev.5d01a73"
+    mVersionName = "1.25.1-dev.56c1004"
 
     mLibraryName = "skyflow-android"
     mLibraryDescription = "Skyflow’s android SDK can be used to securely collect, tokenize, and display sensitive data in the mobile without exposing your front-end infrastructure to sensitive data."

--- a/Skyflow/src/main/kotlin/Skyflow/TextField.kt
+++ b/Skyflow/src/main/kotlin/Skyflow/TextField.kt
@@ -162,6 +162,7 @@ class TextField @JvmOverloads constructor(
                         null
                     )
                     drawableIcon = copyIcon
+                    drawableRight = drawableIcon
                 }, 2000) // 2000 milliseconds = 2 seconds
             }
         }
@@ -319,9 +320,13 @@ class TextField @JvmOverloads constructor(
         isCardMetadataUpdated = true
         this.options.cardMetadata = updateCollectOptions.cardMetadata
         this.setupField(this.collectInput, this.options)
-        if (updateCollectOptions.cardMetadata.scheme.size < 2) {
-            invokeUserOnChangeListener()
-        }
+
+        val defaultCardType = if (this.options.cardMetadata.scheme.size > 1)
+            this.options.cardMetadata.scheme[0]
+        else cardType
+        updateCardChoice(defaultCardType, true)
+        changeCardIcon(defaultCardType)
+        invokeUserOnChangeListener()
     }
 
     @RequiresApi(Build.VERSION_CODES.JELLY_BEAN_MR1)

--- a/Skyflow/src/test/java/com/Skyflow/CollectTest.kt
+++ b/Skyflow/src/test/java/com/Skyflow/CollectTest.kt
@@ -1584,10 +1584,16 @@ class CollectTest {
         val cardNumber = container.create(activity, collectInput, options)
         cardNumber.onAttachedToWindow()
 
+        var scheme = arrayOf<CardType>()
         cardNumber.on(EventName.CHANGE) { state ->
-            val value = state.get("value")
-            val cards = getCardSchemes(value.toString().length)
-            cardNumber.update(CollectElementOptions(cardMetadata = CardMetadata(cards)))
+            val value = state.getString("value")
+            if (value.length < 8 && scheme.isNotEmpty()) {
+                scheme = arrayOf(CardType.CARTES_BANCAIRES)
+                cardNumber.update(CollectElementOptions(cardMetadata = CardMetadata(scheme)))
+            } else if (value.length >= 8 && scheme.isEmpty()) {
+                scheme = getCardSchemes(value.length)
+                cardNumber.update(CollectElementOptions(cardMetadata = CardMetadata(scheme)))
+            }
         }
 
         var state = StateforText(cardNumber)
@@ -1598,7 +1604,7 @@ class CollectTest {
         state = StateforText(cardNumber)
         Assert.assertTrue(state.getInternalState().getBoolean("isRequired"))
         Assert.assertNotNull(cardNumber.inputField.compoundDrawablesRelative[2])
-        Assert.assertEquals(CardType.MASTERCARD, cardNumber.cardType)
+        Assert.assertEquals(CardType.CARTES_BANCAIRES, cardNumber.cardType)
     }
 }
 

--- a/samples/src/main/java/com/Skyflow/CardBrandChoiceActivity.kt
+++ b/samples/src/main/java/com/Skyflow/CardBrandChoiceActivity.kt
@@ -111,13 +111,15 @@ class CardBrandChoiceActivity : AppCompatActivity() {
         }
 
         var scheme = arrayOf<CardType>()
+        var calledUpdate = false
         cardNumber.on(EventName.CHANGE) { state ->
             Log.d(TAG, "change: state $state")
             val value = state.getString("value")
             if (value.length < 8 && scheme.isNotEmpty()) {
                 scheme = arrayOf()
                 cardNumber.update(CollectElementOptions(cardMetadata = CardMetadata(scheme)))
-            } else if (value.length >= 8 && scheme.isEmpty()) {
+                calledUpdate = false
+            } else if (value.length >= 8 && scheme.isEmpty() && !calledUpdate) {
                 binLookup(value, object : Callback {
                     override fun onSuccess(responseBody: Any) {
                         scheme = getCardSchemes(responseBody as JSONArray)
@@ -132,6 +134,7 @@ class CardBrandChoiceActivity : AppCompatActivity() {
                         println(exception)
                     }
                 })
+                calledUpdate = true
             }
         }
 


### PR DESCRIPTION
This PR contains changes for enhancing card brand choice behaviour, updated sample and CHANGELOG
## Why
- The card brand choice behaviour required some enhancements.
- Now, the card icon for first option provided in `scheme` will be rendered in UI.
- The sample is optimised for better performance.
- The CHANGELOG is updated to keep track of all the changes.

## Goal
- This gives the flexibility to control the overall UX of card brand choice selection to the users.
- Better sample for client use that is optimised and less prone to errors.
- Updated CHANGELOG to keep track for all the changes.

## Testing
- Tested the changes manually
- Modified existing unit tests to cover new changes